### PR TITLE
make string reps generate valid JS syntax and not lose characters

### DIFF
--- a/src/reps/long-string.js
+++ b/src/reps/long-string.js
@@ -1,6 +1,7 @@
 // Dependencies
 const React = require("react");
 const {
+  escapeString,
   sanitizeString,
   isGrip,
   wrapRender,
@@ -50,8 +51,8 @@ const LongStringRep = React.createClass({
     if (string.length < length) {
       string += "\u2026";
     }
-    let formattedString = useQuotes ? `"${string}"` : string;
-    return span(config, sanitizeString(formattedString));
+    let formattedString = useQuotes ? escapeString(string) : sanitizeString(string);
+    return span(config, formattedString);
   }),
 });
 

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -154,7 +154,7 @@ function sanitizeString(text) {
   // (horizontal) tab (HT: \x09) and newline (LF: \x0A, CR: \x0D),
   // with unicode replacement character (u+fffd).
   // eslint-disable-next-line no-control-regex
-  let re = new RegExp("[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]", "g");
+  let re = new RegExp("[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]", "g");
   return text.replace(re, "\ufffd");
 }
 

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -28,17 +28,101 @@ function escapeNewLines(value) {
   return value.replace(/\r/gm, "\\r").replace(/\n/gm, "\\n");
 }
 
+// Map from character code to the corresponding escape sequence.  \0
+// isn't here because it would require special treatment in some
+// situations.  \b, \f, and \v aren't here because they aren't very
+// common.  \' isn't here because there's no need, we only
+// double-quote strings.
+const escapeMap = {
+  // Tab.
+  9: "\\t",
+  // Newline.
+  0xa: "\\n",
+  // Carriage return.
+  0xd: "\\r",
+  // Quote.
+  0x22: "\\\"",
+  // Backslash.
+  0x5c: "\\\\",
+};
+
+// Regexp that matches any character we might possibly want to escape.
+// Note that we over-match here, because it's difficult to, say, match
+// an unpaired surrogate with a regexp.  The details are worked out by
+// the replacement function; see |escapeString|.
+const escapeRegexp = new RegExp(
+  "[" +
+  // Quote and backslash.
+  "\"\\\\" +
+  // Controls.
+  "\x00-\x1f" +
+  // More controls.
+  "\x7f-\x9f" +
+  // BOM
+  "\ufeff" +
+  // Replacement characters and non-characters.
+  "\ufffc-\uffff" +
+  // Surrogates.
+  "\ud800-\udfff" +
+  // Mathematical invisibles.
+  "\u2061-\u2064" +
+  // Line and paragraph separators.
+  "\u2028-\u2029" +
+  // Private use area.
+  "\ue000-\uf8ff" +
+  "]", "g");
+
+/**
+ * Escape a string so that the result is viewable and valid JS.
+ * Control characters, other invisibles, invalid characters,
+ * backslash, and double quotes are escaped.  The resulting string is
+ * surrounded by double quotes.
+ *
+ * @param {String} str
+ *        the input
+ * @return {String} the escaped string
+ */
+function escapeString(str) {
+  return "\"" + str.replace(escapeRegexp, (match, offset) => {
+    let c = match.charCodeAt(0);
+    if (c in escapeMap) {
+      return escapeMap[c];
+    }
+    if (c >= 0xd800 && c <= 0xdfff) {
+      // Find the full code point containing the surrogate, with a
+      // special case for a trailing surrogate at the start of the
+      // string.
+      if (c >= 0xdc00 && offset > 0) {
+        --offset;
+      }
+      let codePoint = str.codePointAt(offset);
+      if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+        // Unpaired surrogate.
+        return "\\u" + codePoint.toString(16);
+      } else if (codePoint >= 0xf0000 && codePoint <= 0x10fffd) {
+        // Private use area.  Because we visit each pair of a such a
+        // character, return the empty string for one half and the
+        // real result for the other, to avoid duplication.
+        if (c <= 0xdbff) {
+          return "\\u{" + codePoint.toString(16) + "}";
+        }
+        return "";
+      }
+      // Other surrogate characters are passed through.
+      return match;
+    }
+    return "\\u" + ("0000" + c.toString(16)).substr(-4);
+  }) + "\"";
+}
+
 function cropMultipleLines(text, limit) {
   return escapeNewLines(cropString(text, limit));
 }
 
-function cropString(text, limit, alternativeText) {
+function rawCropString(text, limit, alternativeText) {
   if (!alternativeText) {
     alternativeText = "\u2026";
   }
-
-  // Make sure it's a string and sanitize it.
-  text = sanitizeString(text + "");
 
   // Crop the string only if a limit is actually specified.
   if (!limit || limit <= 0) {
@@ -59,6 +143,10 @@ function cropString(text, limit, alternativeText) {
   }
 
   return text;
+}
+
+function cropString(text, limit, alternativeText) {
+  return rawCropString(sanitizeString(text + ""), limit, alternativeText);
 }
 
 function sanitizeString(text) {
@@ -266,7 +354,9 @@ module.exports = {
   createFactories,
   isGrip,
   cropString,
+  rawCropString,
   sanitizeString,
+  escapeString,
   wrapRender,
   cropMultipleLines,
   parseURLParams,

--- a/src/reps/string.js
+++ b/src/reps/string.js
@@ -2,7 +2,9 @@
 const React = require("react");
 
 const {
-  cropString,
+  escapeString,
+  rawCropString,
+  sanitizeString,
   wrapRender,
 } = require("./rep-utils");
 
@@ -39,17 +41,17 @@ const StringRep = React.createClass({
       config.style = style;
     }
 
-    if (member && member.open) {
-      return span(config, "\"" + text + "\"");
+    if (this.props.useQuotes) {
+      text = escapeString(text);
+    } else {
+      text = sanitizeString(text);
     }
 
-    let croppedString = this.props.cropLimit ?
-      cropString(text, this.props.cropLimit) : cropString(text);
+    if ((!member || !member.open) && this.props.cropLimit) {
+      text = rawCropString(text, this.props.cropLimit);
+    }
 
-    let formattedString = this.props.useQuotes ?
-      "\"" + croppedString + "\"" : croppedString;
-
-    return span(config, formattedString);
+    return span(config, text);
   }),
 });
 

--- a/src/test/mochitest/test_reps_long-string.html
+++ b/src/test/mochitest/test_reps_long-string.html
@@ -38,12 +38,16 @@ window.onload = Task.async(function* () {
     SimpleTest.finish();
   }
 
+  function quoteNewlines(text) {
+    return text.split("\n").join("\\n");
+  }
+
   function testMultiline() {
     const stub = getGripStub("testMultiline");
     const renderedComponent = renderComponent(
       LongStringRep.rep, { object: stub });
 
-    is(renderedComponent.textContent, `"${stub.initial}…"`,
+    is(renderedComponent.textContent, quoteNewlines(`"${stub.initial}…"`),
       "LongString rep has expected text content for multiline string");
   }
 
@@ -53,7 +57,7 @@ window.onload = Task.async(function* () {
 
     is(
       renderedComponent.textContent,
-      `"a\naaaaaaaaaaaaaaaaaa…"`,
+      `"a\\naaaaaaaaaaaaaaaaaa…"`,
       "LongString rep has expected text content for multiline string " +
       "with specified number of characters");
   }
@@ -63,7 +67,7 @@ window.onload = Task.async(function* () {
     const renderedComponent = renderComponent(
       LongStringRep.rep, { object: stub, member: {open: true}, cropLimit: 20 });
 
-    is(renderedComponent.textContent, `"${stub.initial}…"`,
+    is(renderedComponent.textContent, quoteNewlines(`"${stub.initial}…"`),
       "LongString rep has expected text content for multiline string when open");
   }
 
@@ -72,7 +76,7 @@ window.onload = Task.async(function* () {
     const renderedComponentOpen = renderComponent(
       LongStringRep.rep, { object: stub, member: {open: true}, cropLimit: 20 });
 
-    is(renderedComponentOpen.textContent, `"${stub.fullText}"`,
+    is(renderedComponentOpen.textContent, quoteNewlines(`"${stub.fullText}"`),
       "LongString rep has expected text content when grip has a fullText " +
       "property and is open");
 
@@ -80,7 +84,7 @@ window.onload = Task.async(function* () {
       LongStringRep.rep, { object: stub, cropLimit: 20 });
 
     is(renderedComponentNotOpen.textContent,
-      `"a\naaaaaaaaaaaaaaaaaa…"`,
+      `"a\\naaaaaaaaaaaaaaaaaa…"`,
       "LongString rep has expected text content when grip has a fullText " +
       "property and is not open");
   }

--- a/src/test/mochitest/test_reps_string.html
+++ b/src/test/mochitest/test_reps_string.html
@@ -20,57 +20,77 @@ window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, StringRep } = REPS;
 
+  const test_cases = [{
+    name: "testMultiline",
+    props: {
+      object: "aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n",
+    },
+    result: "\"aaaaaaaaaaaaaaaaaaaaa\\nbbbbbbbbbbbbbbbbbbb\\ncccccccccccccccc\\n\""
+  }, {
+    name: "testMultilineLimit",
+    props: {
+      object: "aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n",
+      cropLimit: 20
+    },
+    result: "\"aaaaaaaaa…cccccc\\n\""
+  }, {
+    name: "testMultilineOpen",
+    props: {
+      object: "aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n",
+      member: { open: true }
+    },
+    result: "\"aaaaaaaaaaaaaaaaaaaaa\\nbbbbbbbbbbbbbbbbbbb\\ncccccccccccccccc\\n\""
+  }, {
+    name: "testUseQuotes",
+    props: {
+      object: "abc",
+      useQuotes: false
+    },
+    result: "abc"
+  }, {
+    name: "testNonPrintableCharacters",
+    props: {
+      object: "a\x01b",
+      useQuotes: false
+    },
+    result: "a\ufffdb"
+  }, {
+    name: "testQuoting",
+    props: {
+      object: "\t\n\r\"'\\\x1f\x9f\ufeff\ufffe\ud8000\u2063\ufffc\u2028\ueeee",
+      useQuotes: true
+    },
+    result: "\"\\t\\n\\r\\\"'\\\\\\u001f\\u009f\\ufeff\\ufffe\\ud8000\\u2063\\ufffc\\u2028\\ueeee\""
+  }, {
+    name: "testUnpairedSurrogate",
+    props: {
+      object: "\uDC23",
+      useQuotes: true
+    },
+    result: "\"\\udc23\""
+  }, {
+    name: "testValidSurrogate",
+    props: {
+      object: "\ud83d\udeec",
+      useQuotes: true
+    },
+    result: "\"\ud83d\udeec\""
+  }];
+
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testMultiline") });
+    const renderedRep = shallowRenderComponent(Rep, test_cases[0].props);
     is(renderedRep.type, StringRep.rep, `Rep correctly selects ${StringRep.rep.displayName}`);
 
     // Test rendering
-    yield testMultiline();
-    yield testMultilineOpen();
-    yield testMultilineLimit();
-    yield testUseQuotes();
-    yield testNonPritableCharacters();
+    for (let test of test_cases) {
+      const renderedComponent = renderComponent(StringRep.rep, test.props);
+      is(renderedComponent.textContent, test.result, "String rep " + test.name);
+    }
   } catch(e) {
     ok(false, "Got an error: " + DevToolsUtils.safeErrorString(e));
   } finally {
     SimpleTest.finish();
-  }
-
-  function testMultiline() {
-    const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testMultiline") });
-    is(renderedComponent.textContent, "\"aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n\"", "String rep has expected text content for multiline string");
-  }
-
-  function testMultilineLimit() {
-    const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testMultiline"), cropLimit: 20 });
-    is(renderedComponent.textContent, "\"aaaaaaaaaa…cccccccc\n\"", "String rep has expected text content for multiline string with specified number of characters");
-  }
-
-  function testMultilineOpen() {
-    const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testMultiline"), member: {open: true} });
-    is(renderedComponent.textContent, "\"aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n\"", "String rep has expected text content for multiline string when open");
-  }
-
-  function testUseQuotes(){
-     const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testUseQuotes"), useQuotes: false });
-     is(renderedComponent.textContent, "abc", "String rep was expected to omit quotes");
-  }
-
-  function testNonPritableCharacters(){
-     const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testNonPritableCharacters"), useQuotes: false });
-     is(renderedComponent.textContent, "a\ufffdb", "String rep was expected to omit non printable characters");
-  }
-
-  function getGripStub(name) {
-    switch (name) {
-      case "testMultiline":
-        return "aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n";
-      case "testUseQuotes":
-        return "abc";
-      case "testNonPritableCharacters":
-        return "a\x01b";
-    }
   }
 });
 </script>


### PR DESCRIPTION
Currently reps can completely drop a \n from a string.  This was very confusing to me when I was debugging...

This patch tries to quote "weird" things and generally make the generated strings valid JS.  There are some notes in https://bugzilla.mozilla.org/show_bug.cgi?id=1258584, but my view has evolved a bit since then.

A couple other ideas come to mind:

* The ellipsis inserted by the rep could be styled differently so that users don't confuse it with an actual ellipsis appearing in the string
* There could be an "ASCII" view that \u-quotes all non-ASCII characters; or maybe some kind of "copy as JS" menu item.

Note that the reps demo shows newlines looking like newlines.  The debugger and the reps disagree on the styling of `.objectBox-string`, which might be a bug as well.  But even if that bug is fixed I think it's better to try to make the strings more JS-like and more explicit as well.