### PR TITLE
forward click event to onInspectIconClick callback

### DIFF
--- a/src/reps/element-node.js
+++ b/src/reps/element-node.js
@@ -123,7 +123,7 @@ const ElementNode = React.createClass({
           draggable: false,
           // TODO: Localize this with "openNodeInInspector" when Bug 1317038 lands
           title: "Click to select the node in the inspector",
-          onClick: () => onInspectIconClick(object)
+          onClick: (e) => onInspectIconClick(object, e)
         });
       }
     }

--- a/src/reps/text-node.js
+++ b/src/reps/text-node.js
@@ -77,7 +77,7 @@ let TextNode = React.createClass({
           draggable: false,
           // TODO: Localize this with "openNodeInInspector" when Bug 1317038 lands
           title: "Click to select the node in the inspector",
-          onClick: () => onInspectIconClick(grip)
+          onClick: (e) => onInspectIconClick(grip, e)
         });
       }
     }

--- a/src/test/mochitest/test_reps_element-node.html
+++ b/src/test/mochitest/test_reps_element-node.html
@@ -233,8 +233,11 @@ window.onload = Task.async(function* () {
     const attachedActorIds = getStubAttachedActorIds(grips);
 
     let inspectIconClickedValue = null;
-    let onInspectIconClick = (object) => {
+    let inspectIconClickedEvent = null;
+
+    let onInspectIconClick = (object, event) => {
       inspectIconClickedValue = object;
+      inspectIconClickedEvent = event;
     };
 
     const renderedComponentWithoutInspectIcon = renderComponent(ElementNode.rep, {
@@ -265,6 +268,8 @@ window.onload = Task.async(function* () {
 
     is(inspectIconClickedValue, grips[0],
       "onInspectIconClick is called with expected value when inspect icon is clicked");
+    ok(inspectIconClickedEvent !== null && inspectIconClickedEvent.type === "click",
+      "onInspectIconClick forwarded the original event to the callback");
   }
 
   function getGripStub(name) {

--- a/src/test/mochitest/test_reps_text-node.html
+++ b/src/test/mochitest/test_reps_text-node.html
@@ -172,8 +172,11 @@ window.onload = Task.async(function* () {
     const attachedActorIds = getStubAttachedActorIds(grips);
 
     let inspectIconClickedValue = null;
-    let onInspectIconClick = (object) => {
+    let inspectIconClickedEvent = null;
+
+    let onInspectIconClick = (object, event) => {
       inspectIconClickedValue = object;
+      inspectIconClickedEvent = event;
     };
 
     const renderedComponentWithoutInspectIcon = renderComponent(TextNode.rep, {
@@ -196,6 +199,8 @@ window.onload = Task.async(function* () {
 
     is(inspectIconClickedValue, grips[0],
       "onInspectIconClick is called with expected value when inspect icon is clicked");
+    ok(inspectIconClickedEvent !== null && inspectIconClickedEvent.type === "click",
+      "onInspectIconClick forwarded the original event to the callback");
   }
 });
 </script>


### PR DESCRIPTION
This would allow for an easier integration for the reps used in the layout panel:

```js
Rep(
  {
    defaultRep: ElementNode,
    object: this.translateNodeFrontToGrip(nodeFront),
    onDOMNodeMouseOut: () => onHideBoxModelHighlighter(),
    onDOMNodeMouseOver: () => onShowBoxModelHighlighterForNode(nodeFront),
    onInspectIconClick: (object, e) => {
      setSelectedNode(nodeFront);
      // Call preventDefault to avoid updating the checkbox state.
      e.preventDefault();
    },
  }
)
```