### PR TITLE
Quote property names when required

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,14 @@ const {
   parseURLEncodedText,
   parseURLParams,
   getSelectableInInspectorGrips,
+  maybeEscapePropertyName,
 } = require("./reps/rep-utils");
 
 module.exports = {
   REPS,
   MODE,
   createFactories,
+  maybeEscapePropertyName,
   parseURLEncodedText,
   parseURLParams,
   getSelectableInInspectorGrips,

--- a/src/reps/grip.js
+++ b/src/reps/grip.js
@@ -96,7 +96,12 @@ const GripRep = React.createClass({
     }
 
     const truncate = Object.keys(properties).length > max;
-    let propsArray = this.getProps(properties, indexes, truncate);
+    // The server synthesizes some property names for a Proxy, like
+    // <target> and <handler>; we don't want to quote these because,
+    // as synthetic properties, they appear more natural when
+    // unquoted.
+    const suppressQuotes = object.class === "Proxy";
+    let propsArray = this.getProps(properties, indexes, truncate, suppressQuotes);
     if (truncate) {
       // There are some undisplayed props. Then display "more...".
       let objectLink = this.props.objectLink || span;
@@ -117,9 +122,11 @@ const GripRep = React.createClass({
    * @param {Object} properties Props object.
    * @param {Array} indexes Indexes of props.
    * @param {Boolean} truncate true if the grip will be truncated.
+   * @param {Boolean} suppressQuotes true if we should suppress quotes
+   *                  on property names.
    * @return {Array} Props.
    */
-  getProps: function (properties, indexes, truncate) {
+  getProps: function (properties, indexes, truncate, suppressQuotes) {
     let propsArray = [];
 
     // Make indexes ordered by ascending.
@@ -140,6 +147,7 @@ const GripRep = React.createClass({
         defaultRep: Grip,
         // Do not propagate title to properties reps
         title: undefined,
+        suppressQuotes,
       })));
     });
 

--- a/src/reps/promise.js
+++ b/src/reps/promise.js
@@ -53,6 +53,7 @@ const PromiseRep = React.createClass({
         object,
         equal: ": ",
         delim: i < keys.length - 1 ? ", " : "",
+        suppressQuotes: true,
       }));
     });
   },

--- a/src/reps/prop-rep.js
+++ b/src/reps/prop-rep.js
@@ -2,6 +2,7 @@
 const React = require("react");
 const {
   createFactories,
+  maybeEscapePropertyName,
   wrapRender,
 } = require("./rep-utils");
 const { MODE } = require("./constants");
@@ -33,6 +34,10 @@ let PropRep = React.createClass({
     onDOMNodeMouseOver: React.PropTypes.func,
     onDOMNodeMouseOut: React.PropTypes.func,
     onInspectIconClick: React.PropTypes.func,
+    // Normally a PropRep will quote a property name that isn't valid
+    // when unquoted; but this flag can be used to suppress the
+    // quoting.
+    suppressQuotes: React.PropTypes.bool,
   },
 
   render: wrapRender(function () {
@@ -43,13 +48,17 @@ let PropRep = React.createClass({
       mode,
       equal,
       delim,
+      suppressQuotes,
     } = this.props;
 
     let key;
     // The key can be a simple string, for plain objects,
     // or another object for maps and weakmaps.
-    if (typeof this.props.name === "string") {
-      key = span({"className": "nodeName"}, this.props.name);
+    if (typeof name === "string") {
+      if (!suppressQuotes) {
+        name = maybeEscapePropertyName(name);
+      }
+      key = span({"className": "nodeName"}, name);
     } else {
       key = Rep(Object.assign({}, this.props, {
         object: name,

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -115,6 +115,29 @@ function escapeString(str) {
   }) + "\"";
 }
 
+/**
+ * Escape a property name, if needed.  "Escaping" in this context
+ * means surrounding the property name with quotes.
+ *
+ * @param {String}
+ *        name the property name
+ * @return {String} either the input, or the input surrounded by
+ *                  quotes, properly quoted in JS syntax.
+ */
+function maybeEscapePropertyName(name) {
+  // Quote the property name if it needs quoting.  This particular
+  // test is an approximation; see
+  // https://mathiasbynens.be/notes/javascript-properties.  However,
+  // the full solution requires a fair amount of Unicode data, and so
+  // let's defer that until either it's important, or the \p regexp
+  // syntax lands, see
+  // https://github.com/tc39/proposal-regexp-unicode-property-escapes.
+  if (!/^\w+$/.test(name)) {
+    name = escapeString(name);
+  }
+  return name;
+}
+
 function cropMultipleLines(text, limit) {
   return escapeNewLines(cropString(text, limit));
 }
@@ -364,4 +387,5 @@ module.exports = {
   getFileName,
   getURLDisplayString,
   getSelectableInInspectorGrips,
+  maybeEscapePropertyName,
 };

--- a/src/test/mochitest/test_reps_grip-map.html
+++ b/src/test/mochitest/test_reps_grip-map.html
@@ -156,7 +156,7 @@ window.onload = Task.async(function* () {
     // `new Map([["key-a","value-a"], ["key-b","value-b"], ["key-c","value-c"]])`
     const testName = "testMaxEntries";
 
-    const defaultOutput = `Map { key-a: "value-a", key-b: "value-b", key-c: "value-c" }`;
+    const defaultOutput = `Map { "key-a": "value-a", "key-b": "value-b", "key-c": "value-c" }`;
 
     const modeTests = [
       {
@@ -186,10 +186,10 @@ window.onload = Task.async(function* () {
     const testName = "testMoreThanMaxEntries";
 
     const defaultOutput =
-      `Map { key-0: "value-0", key-1: "value-1", key-2: "value-2", 98 more… }`;
+      `Map { "key-0": "value-0", "key-1": "value-1", "key-2": "value-2", 98 more… }`;
 
     // Generate string with 101 entries, which is the max limit for 'long' mode.
-    let longString = Array.from({length: 10}).map((_, i) => `key-${i}: "value-${i}"`);
+    let longString = Array.from({length: 10}).map((_, i) => `"key-${i}": "value-${i}"`);
     const longOutput = `Map { ${longString.join(", ")}, 91 more… }`;
 
     const modeTests = [
@@ -220,9 +220,9 @@ window.onload = Task.async(function* () {
     const testName = "testUninterestingEntries";
 
     const defaultOutput =
-      `Map { key-a: null, key-c: "value-c", key-d: 4, 1 more… }`;
+      `Map { "key-a": null, "key-c": "value-c", "key-d": 4, 1 more… }`;
     const longOutput =
-      `Map { key-a: null, key-b: undefined, key-c: "value-c", key-d: 4 }`;
+      `Map { "key-a": null, "key-b": undefined, "key-c": "value-c", "key-d": 4 }`;
 
     const modeTests = [
       {

--- a/src/test/mochitest/test_reps_object.html
+++ b/src/test/mochitest/test_reps_object.html
@@ -30,6 +30,9 @@ window.onload = Task.async(function* () {
     yield testMoreThanMaxProps();
     yield testUninterestingProps();
 
+    // Test that unusual property names are escaped.
+    yield testEscapedPropertyNames();
+
     // Test that properties are rendered as expected by PropRep
     yield testNested();
 
@@ -157,6 +160,32 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, "testUninterestingProps", componentUnderTest, stub);
+  }
+
+  function testEscapedPropertyNames() {
+    const stub = {"":1, "quote-this":2, noquotes:3};
+    const defaultOutput = `Object { "": 1, "quote-this": 2, noquotes: 3 }`;
+
+    const modeTests = [
+      {
+        mode: undefined,
+        expectedOutput: defaultOutput,
+      },
+      {
+        mode: MODE.TINY,
+        expectedOutput: `Object`,
+      },
+      {
+        mode: MODE.SHORT,
+        expectedOutput: defaultOutput,
+      },
+      {
+        mode: MODE.LONG,
+        expectedOutput: defaultOutput,
+      }
+    ];
+
+    testRepRenderModes(modeTests, "testEscapedPropertyNames", componentUnderTest, stub);
   }
 
   function testNested() {


### PR DESCRIPTION
This changes reps to quote property names when quotes would be
required by JS object literal syntax.  The precise test implemented
here is a conservative approximation, to avoid pulling in Unicode
character property info.  |maybeEscapePropertyName| is exported
for use by the object inspector.

This is https://bugzilla.mozilla.org/show_bug.cgi?id=1137281.