### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-reps",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Devtools Reps",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
A version bump is needed so that the property name quoting feature can
be added to the debugger.