### PR TITLE
release: bump version to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-reps",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Devtools Reps",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Same content as v0.3.1.

Let's wait for https://bugzilla.mozilla.org/show_bug.cgi?id=1344156 before merging.
try https://treeherder.mozilla.org/#/jobs?repo=try&revision=f03d2bc6069bdb4a4038be9e165df7322d23f635