### PR TITLE
remove version from script type attribute

### DIFF
--- a/src/test/mochitest/test_reps_array.html
+++ b/src/test/mochitest/test_reps_array.html
@@ -14,8 +14,8 @@ Test ArrayRep rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 /* import-globals-from head.js */
 

--- a/src/test/mochitest/test_reps_attribute.html
+++ b/src/test/mochitest/test_reps_attribute.html
@@ -14,8 +14,8 @@ Test Attribute rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Attribute } = REPS;

--- a/src/test/mochitest/test_reps_comment-node.html
+++ b/src/test/mochitest/test_reps_comment-node.html
@@ -14,8 +14,8 @@ Test comment-node rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_date-time.html
+++ b/src/test/mochitest/test_reps_date-time.html
@@ -14,8 +14,8 @@ Test DateTime rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, DateTime } = REPS;

--- a/src/test/mochitest/test_reps_document.html
+++ b/src/test/mochitest/test_reps_document.html
@@ -14,8 +14,8 @@ Test Document rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Document } = REPS;

--- a/src/test/mochitest/test_reps_element-node.html
+++ b/src/test/mochitest/test_reps_element-node.html
@@ -14,8 +14,8 @@ Test Element node rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_error.html
+++ b/src/test/mochitest/test_reps_error.html
@@ -14,8 +14,8 @@ Test Error rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_event.html
+++ b/src/test/mochitest/test_reps_event.html
@@ -14,8 +14,8 @@ Test Event rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const {
     REPS,

--- a/src/test/mochitest/test_reps_failure.html
+++ b/src/test/mochitest/test_reps_failure.html
@@ -14,8 +14,8 @@ Test fallback for rep rendering when a rep fails to render.
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");

--- a/src/test/mochitest/test_reps_function.html
+++ b/src/test/mochitest/test_reps_function.html
@@ -14,8 +14,8 @@ Test Func rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Func } = REPS;

--- a/src/test/mochitest/test_reps_grip-array.html
+++ b/src/test/mochitest/test_reps_grip-array.html
@@ -14,8 +14,8 @@ Test GripArray rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const {
     REPS,

--- a/src/test/mochitest/test_reps_grip-map.html
+++ b/src/test/mochitest/test_reps_grip-map.html
@@ -14,8 +14,8 @@ Test GripMap rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_grip.html
+++ b/src/test/mochitest/test_reps_grip.html
@@ -14,8 +14,8 @@ Test grip rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const {
     REPS,

--- a/src/test/mochitest/test_reps_infinity.html
+++ b/src/test/mochitest/test_reps_infinity.html
@@ -14,8 +14,8 @@ Test Infinity rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_long-string.html
+++ b/src/test/mochitest/test_reps_long-string.html
@@ -14,8 +14,8 @@ Test LongString rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, LongStringRep } = REPS;

--- a/src/test/mochitest/test_reps_nan.html
+++ b/src/test/mochitest/test_reps_nan.html
@@ -14,8 +14,8 @@ Test NaN rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_null.html
+++ b/src/test/mochitest/test_reps_null.html
@@ -14,8 +14,8 @@ Test Null rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");

--- a/src/test/mochitest/test_reps_number.html
+++ b/src/test/mochitest/test_reps_number.html
@@ -14,8 +14,8 @@ Test Number rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Number } = REPS;

--- a/src/test/mochitest/test_reps_object-with-text.html
+++ b/src/test/mochitest/test_reps_object-with-text.html
@@ -14,8 +14,8 @@ Test ObjectWithText rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");

--- a/src/test/mochitest/test_reps_object-with-url.html
+++ b/src/test/mochitest/test_reps_object-with-url.html
@@ -14,8 +14,8 @@ Test ObjectWithURL rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");

--- a/src/test/mochitest/test_reps_object.html
+++ b/src/test/mochitest/test_reps_object.html
@@ -14,8 +14,8 @@ Test Obj rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Obj } = REPS;

--- a/src/test/mochitest/test_reps_promise.html
+++ b/src/test/mochitest/test_reps_promise.html
@@ -14,8 +14,8 @@ Test Promise rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_regexp.html
+++ b/src/test/mochitest/test_reps_regexp.html
@@ -14,8 +14,8 @@ Test RegExp rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");

--- a/src/test/mochitest/test_reps_string.html
+++ b/src/test/mochitest/test_reps_string.html
@@ -14,8 +14,8 @@ Test String rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, StringRep } = REPS;

--- a/src/test/mochitest/test_reps_stylesheet.html
+++ b/src/test/mochitest/test_reps_stylesheet.html
@@ -14,8 +14,8 @@ Test Stylesheet rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");

--- a/src/test/mochitest/test_reps_symbol.html
+++ b/src/test/mochitest/test_reps_symbol.html
@@ -14,8 +14,8 @@ Test Symbol rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 /* import-globals-from head.js */
 

--- a/src/test/mochitest/test_reps_text-node.html
+++ b/src/test/mochitest/test_reps_text-node.html
@@ -14,8 +14,8 @@ Test text-node rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 "use strict";
 
 window.onload = Task.async(function* () {

--- a/src/test/mochitest/test_reps_undefined.html
+++ b/src/test/mochitest/test_reps_undefined.html
@@ -14,8 +14,8 @@ Test undefined rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");

--- a/src/test/mochitest/test_reps_window.html
+++ b/src/test/mochitest/test_reps_window.html
@@ -14,8 +14,8 @@ Test window rep
 </head>
 <body>
 <pre id="test">
-<script src="head.js" type="application/javascript;version=1.8"></script>
-<script type="application/javascript;version=1.8">
+<script src="head.js" type="application/javascript"></script>
+<script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");


### PR DESCRIPTION
This restores the changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1342144 that were overridden when I copied version v0.4.0 to mozilla-central.

cc @nchevobbe 