### PR TITLE
Moves Reps from Classes to Functional Components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { MODE } = require("./reps/constants");
-const { REPS } = require("./reps/rep");
+const { REPS, getRep } = require("./reps/rep");
 const {
   createFactories,
   parseURLEncodedText,
@@ -10,6 +10,7 @@ const {
 
 module.exports = {
   REPS,
+  getRep,
   MODE,
   createFactories,
   maybeEscapePropertyName,

--- a/src/reps/array.js
+++ b/src/reps/array.js
@@ -1,10 +1,10 @@
 // Dependencies
 const React = require("react");
 const {
-  createFactories,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-const Caption = React.createFactory(require("./caption"));
+const Caption = require("./caption");
 const { MODE } = require("./constants");
 
 const ModePropType = React.PropTypes.oneOf(
@@ -19,184 +19,114 @@ const DOM = React.DOM;
  * Renders an array. The array is enclosed by left and right bracket
  * and the max number of rendered items depends on the current mode.
  */
-let ArrayRep = React.createClass({
-  displayName: "ArrayRep",
+ArrayRep.propTypes = {
+  mode: ModePropType,
+  objectLink: React.PropTypes.func,
+  object: React.PropTypes.array.isRequired,
+};
 
-  propTypes: {
-    mode: ModePropType,
-    objectLink: React.PropTypes.func,
-    object: React.PropTypes.array.isRequired,
-  },
+function ArrayRep(props) {
+  let {
+    object,
+    mode = MODE.SHORT,
+  } = props;
 
-  getTitle: function (object, context) {
-    return "[" + object.length + "]";
-  },
+  let items;
+  let brackets;
+  let needSpace = function (space) {
+    return space ? { left: "[ ", right: " ]"} : { left: "[", right: "]"};
+  };
 
-  arrayIterator: function (array, max) {
-    let items = [];
-    let delim;
+  if (mode === MODE.TINY) {
+    let isEmpty = object.length === 0;
+    items = [DOM.span({className: "length"}, isEmpty ? "" : object.length)];
+    brackets = needSpace(false);
+  } else {
+    let max = (mode === MODE.SHORT) ? 3 : 10;
+    items = arrayIterator(props, object, max);
+    brackets = needSpace(items.length > 0);
+  }
 
-    for (let i = 0; i < array.length && i < max; i++) {
-      try {
-        let value = array[i];
+  return (
+    DOM.span({
+      className: "objectBox objectBox-array"},
+      safeObjectLink(props, {
+        className: "arrayLeftBracket",
+        object: object
+      }, brackets.left),
+      ...items,
+      safeObjectLink(props, {
+        className: "arrayRightBracket",
+        object: object
+      }, brackets.right),
+      DOM.span({
+        className: "arrayProperties",
+        role: "group"}
+      )
+    )
+  );
+}
 
-        delim = (i == array.length - 1 ? "" : ", ");
+function arrayIterator(props, array, max) {
+  let items = [];
+  let delim;
 
-        items.push(ItemRep({
-          object: value,
-          // Hardcode tiny mode to avoid recursive handling.
-          mode: MODE.TINY,
-          delim: delim
-        }));
-      } catch (exc) {
-        items.push(ItemRep({
-          object: exc,
-          mode: MODE.TINY,
-          delim: delim
-        }));
-      }
-    }
+  for (let i = 0; i < array.length && i < max; i++) {
+    try {
+      let value = array[i];
 
-    if (array.length > max) {
-      items.push(Caption({
-        object: this.safeObjectLink({
-          object: this.props.object
-        }, (array.length - max) + " more…")
+      delim = (i == array.length - 1 ? "" : ", ");
+
+      items.push(ItemRep({
+        object: value,
+        // Hardcode tiny mode to avoid recursive handling.
+        mode: MODE.TINY,
+        delim: delim
+      }));
+    } catch (exc) {
+      items.push(ItemRep({
+        object: exc,
+        mode: MODE.TINY,
+        delim: delim
       }));
     }
+  }
 
-    return items;
-  },
+  if (array.length > max) {
+    items.push(Caption({
+      object: safeObjectLink(props, {
+        object: props.object
+      }, (array.length - max) + " more…")
+    }));
+  }
 
-  /**
-   * Returns true if the passed object is an array with additional (custom)
-   * properties, otherwise returns false. Custom properties should be
-   * displayed in extra expandable section.
-   *
-   * Example array with a custom property.
-   * let arr = [0, 1];
-   * arr.myProp = "Hello";
-   *
-   * @param {Array} array The array object.
-   */
-  hasSpecialProperties: function (array) {
-    function isInteger(x) {
-      let y = parseInt(x, 10);
-      if (isNaN(y)) {
-        return false;
-      }
-      return x === y.toString();
-    }
-
-    let propsArray = Object.getOwnPropertyNames(array);
-    for (let i = 0; i < propsArray.length; i++) {
-      let p = propsArray[i];
-
-      // Valid indexes are skipped
-      if (isInteger(p)) {
-        continue;
-      }
-
-      // Ignore standard 'length' property, anything else is custom.
-      if (p != "length") {
-        return true;
-      }
-    }
-
-    return false;
-  },
-
-  // Event Handlers
-
-  onToggleProperties: function (event) {
-  },
-
-  onClickBracket: function (event) {
-  },
-
-  safeObjectLink: function (config, ...children) {
-    if (this.props.objectLink) {
-      return this.props.objectLink(Object.assign({
-        object: this.props.object
-      }, config), ...children);
-    }
-
-    if (Object.keys(config).length === 0 && children.length === 1) {
-      return children[0];
-    }
-
-    return DOM.span(config, ...children);
-  },
-
-  render: wrapRender(function () {
-    let {
-      object,
-      mode = MODE.SHORT,
-    } = this.props;
-
-    let items;
-    let brackets;
-    let needSpace = function (space) {
-      return space ? { left: "[ ", right: " ]"} : { left: "[", right: "]"};
-    };
-
-    if (mode === MODE.TINY) {
-      let isEmpty = object.length === 0;
-      items = [DOM.span({className: "length"}, isEmpty ? "" : object.length)];
-      brackets = needSpace(false);
-    } else {
-      let max = (mode === MODE.SHORT) ? 3 : 10;
-      items = this.arrayIterator(object, max);
-      brackets = needSpace(items.length > 0);
-    }
-
-    return (
-      DOM.span({
-        className: "objectBox objectBox-array"},
-        this.safeObjectLink({
-          className: "arrayLeftBracket",
-          object: object
-        }, brackets.left),
-        ...items,
-        this.safeObjectLink({
-          className: "arrayRightBracket",
-          object: object
-        }, brackets.right),
-        DOM.span({
-          className: "arrayProperties",
-          role: "group"}
-        )
-      )
-    );
-  }),
-});
+  return items;
+}
 
 /**
  * Renders array item. Individual values are separated by a comma.
  */
-let ItemRep = React.createFactory(React.createClass({
-  displayName: "ItemRep",
+ItemRep.propTypes = {
+  object: React.PropTypes.any.isRequired,
+  delim: React.PropTypes.string.isRequired,
+  mode: ModePropType,
+};
 
-  propTypes: {
-    object: React.PropTypes.any.isRequired,
-    delim: React.PropTypes.string.isRequired,
-    mode: ModePropType,
-  },
+function ItemRep(props) {
+  const { Rep } = require("./rep");
 
-  render: wrapRender(function () {
-    const { Rep } = createFactories(require("./rep"));
-
-    let object = this.props.object;
-    let delim = this.props.delim;
-    let mode = this.props.mode;
-    return (
-      DOM.span({},
-        Rep({object: object, mode: mode}),
-        delim
-      )
-    );
-  })
-}));
+  let {
+    object,
+    delim,
+    mode,
+  } = props;
+  return (
+    DOM.span({},
+      Rep({object: object, mode: mode}),
+      delim
+    )
+  );
+}
 
 function supportsObject(object, type) {
   return Array.isArray(object) ||
@@ -205,6 +135,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: ArrayRep,
-  supportsObject: supportsObject
+  rep: wrapRender(ArrayRep),
+  supportsObject,
 };

--- a/src/reps/attribute.js
+++ b/src/reps/attribute.js
@@ -3,57 +3,47 @@ const React = require("react");
 
 // Reps
 const {
-  createFactories,
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-const StringRep = require("./string");
+const {rep: StringRep} = require("./string");
 
 // Shortcuts
 const { span } = React.DOM;
-const { rep: StringRepFactory } = createFactories(StringRep);
 
 /**
  * Renders DOM attribute
  */
-let Attribute = React.createClass({
-  displayName: "Attr",
+Attribute.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function Attribute(props) {
+  let {
+    object,
+  } = props;
+  let value = object.preview.value;
 
-  getTitle: function (grip) {
-    return grip.preview.nodeName;
-  },
+  return (
+    safeObjectLink(props, {className: "objectLink-Attr"},
+      span({className: "attrTitle"},
+        getTitle(object)
+      ),
+      span({className: "attrEqual"},
+        "="
+      ),
+      StringRep({object: value})
+    )
+  );
+}
 
-  render: wrapRender(function () {
-    let object = this.props.object;
-    let value = object.preview.value;
-    let objectLink = (config, ...children) => {
-      if (this.props.objectLink) {
-        return this.props.objectLink(Object.assign({object}, config), ...children);
-      }
-      return span(config, ...children);
-    };
-
-    return (
-      objectLink({className: "objectLink-Attr"},
-        span({className: "attrTitle"},
-          this.getTitle(object)
-        ),
-        span({className: "attrEqual"},
-          "="
-        ),
-        StringRepFactory({object: value})
-      )
-    );
-  }),
-});
+function getTitle(grip) {
+  return grip.preview.nodeName;
+}
 
 // Registration
-
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
     return false;
@@ -63,6 +53,6 @@ function supportsObject(grip, type) {
 }
 
 module.exports = {
-  rep: Attribute,
-  supportsObject: supportsObject
+  rep: wrapRender(Attribute),
+  supportsObject,
 };

--- a/src/reps/caption.js
+++ b/src/reps/caption.js
@@ -8,22 +8,18 @@ const { wrapRender } = require("./rep-utils");
  * Renders a caption. This template is used by other components
  * that needs to distinguish between a simple text/value and a label.
  */
-const Caption = React.createClass({
-  displayName: "Caption",
+Caption.propTypes = {
+  object: React.PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.string,
+  ]).isRequired,
+};
 
-  propTypes: {
-    object: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.string,
-    ]).isRequired,
-  },
-
-  render: wrapRender(function () {
-    return (
-      DOM.span({"className": "caption"}, this.props.object)
-    );
-  }),
-});
+function Caption(props) {
+  return (
+    DOM.span({"className": "caption"}, props.object)
+  );
+}
 
 // Exports from this module
-module.exports = Caption;
+module.exports = wrapRender(Caption);

--- a/src/reps/comment-node.js
+++ b/src/reps/comment-node.js
@@ -15,31 +15,27 @@ const { span } = React.DOM;
 /**
  * Renders DOM comment node.
  */
-const CommentNode = React.createClass({
-  displayName: "CommentNode",
+CommentNode.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-  },
+function CommentNode(props) {
+  let {
+    object,
+    mode = MODE.SHORT
+  } = props;
 
-  render: wrapRender(function () {
-    let {
-      object,
-      mode = MODE.SHORT
-    } = this.props;
+  let {textContent} = object.preview;
+  if (mode === MODE.TINY) {
+    textContent = cropMultipleLines(textContent, 30);
+  } else if (mode === MODE.SHORT) {
+    textContent = cropString(textContent, 50);
+  }
 
-    let {textContent} = object.preview;
-    if (mode === MODE.TINY) {
-      textContent = cropMultipleLines(textContent, 30);
-    } else if (mode === MODE.SHORT) {
-      textContent = cropString(textContent, 50);
-    }
-
-    return span({className: "objectBox theme-comment"}, `<!-- ${textContent} -->`);
-  }),
-});
+  return span({className: "objectBox theme-comment"}, `<!-- ${textContent} -->`);
+}
 
 // Registration
 function supportsObject(object, type) {
@@ -51,6 +47,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: CommentNode,
-  supportsObject: supportsObject
+  rep: wrapRender(CommentNode),
+  supportsObject,
 };

--- a/src/reps/date-time.js
+++ b/src/reps/date-time.js
@@ -4,6 +4,7 @@ const React = require("react");
 // Reps
 const {
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 
@@ -13,43 +14,33 @@ const { span } = React.DOM;
 /**
  * Used to render JS built-in Date() object.
  */
-let DateTime = React.createClass({
-  displayName: "Date",
+DateTime.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function DateTime(props) {
+  let grip = props.object;
+  let date;
+  try {
+    date = span({className: "objectBox"},
+      getTitle(props, grip),
+      span({className: "Date"},
+        new Date(grip.preview.timestamp).toISOString()
+      )
+    );
+  } catch (e) {
+    date = span({className: "objectBox"}, "Invalid Date");
+  }
 
-  getTitle: function (grip) {
-    if (this.props.objectLink) {
-      return this.props.objectLink({
-        object: grip
-      }, grip.class + " ");
-    }
-    return "";
-  },
+  return date;
+}
 
-  render: wrapRender(function () {
-    let grip = this.props.object;
-    let date;
-    try {
-      date = span({className: "objectBox"},
-        this.getTitle(grip),
-        span({className: "Date"},
-          new Date(grip.preview.timestamp).toISOString()
-        )
-      );
-    } catch (e) {
-      date = span({className: "objectBox"}, "Invalid Date");
-    }
-
-    return date;
-  }),
-});
+function getTitle(props, grip) {
+  return safeObjectLink(props, {}, grip.class + " ");
+}
 
 // Registration
-
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
     return false;
@@ -60,6 +51,6 @@ function supportsObject(grip, type) {
 
 // Exports from this module
 module.exports = {
-  rep: DateTime,
-  supportsObject: supportsObject
+  rep: wrapRender(DateTime),
+  supportsObject,
 };

--- a/src/reps/document.js
+++ b/src/reps/document.js
@@ -5,6 +5,7 @@ const React = require("react");
 const {
   isGrip,
   getURLDisplayString,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 
@@ -14,50 +15,34 @@ const { span } = React.DOM;
 /**
  * Renders DOM document object.
  */
-let Document = React.createClass({
-  displayName: "Document",
+Document.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function Document(props) {
+  let grip = props.object;
 
-  getLocation: function (grip) {
-    let location = grip.preview.location;
-    return location ? getURLDisplayString(location) : "";
-  },
-
-  getTitle: function (grip) {
-    if (this.props.objectLink) {
-      return span({className: "objectBox"},
-        this.props.objectLink({
-          object: grip
-        }, grip.class + " ")
-      );
-    }
-    return "";
-  },
-
-  getTooltip: function (doc) {
-    return doc.location.href;
-  },
-
-  render: wrapRender(function () {
-    let grip = this.props.object;
-
-    return (
-      span({className: "objectBox objectBox-object"},
-        this.getTitle(grip),
-        span({className: "objectPropValue"},
-          this.getLocation(grip)
-        )
+  return (
+    span({className: "objectBox objectBox-object"},
+      getTitle(props, grip),
+      span({className: "objectPropValue"},
+        getLocation(grip)
       )
-    );
-  }),
-});
+    )
+  );
+}
+
+function getLocation(grip) {
+  let location = grip.preview.location;
+  return location ? getURLDisplayString(location) : "";
+}
+
+function getTitle(props, grip) {
+  return safeObjectLink(props, {}, grip.class + " ");
+}
 
 // Registration
-
 function supportsObject(object, type) {
   if (!isGrip(object)) {
     return false;
@@ -68,6 +53,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: Document,
-  supportsObject: supportsObject
+  rep: wrapRender(Document),
+  supportsObject,
 };

--- a/src/reps/element-node.js
+++ b/src/reps/element-node.js
@@ -4,6 +4,7 @@ const React = require("react");
 // Utils
 const {
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 const { MODE } = require("./constants");
@@ -16,129 +17,119 @@ const { span } = React.DOM;
 /**
  * Renders DOM element node.
  */
-const ElementNode = React.createClass({
-  displayName: "ElementNode",
+ElementNode.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  attachedActorIds: React.PropTypes.array,
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    attachedActorIds: React.PropTypes.array,
-    onDOMNodeMouseOver: React.PropTypes.func,
-    onDOMNodeMouseOut: React.PropTypes.func,
-    onInspectIconClick: React.PropTypes.func,
-    objectLink: React.PropTypes.func,
-  },
+function ElementNode(props) {
+  let {
+    object,
+    mode,
+    attachedActorIds,
+    onDOMNodeMouseOver,
+    onDOMNodeMouseOut,
+    onInspectIconClick,
+  } = props;
+  let elements = getElements(object, mode);
 
-  getElements: function (grip, mode) {
-    let {attributes, nodeName} = grip.preview;
-    const nodeNameElement = span({
-      className: "tag-name theme-fg-color3"
-    }, nodeName);
+  let isInTree = attachedActorIds ? attachedActorIds.includes(object.actor) : true;
 
-    if (mode === MODE.TINY) {
-      let elements = [nodeNameElement];
-      if (attributes.id) {
-        elements.push(
-          span({className: "attr-name theme-fg-color2"}, `#${attributes.id}`));
-      }
-      if (attributes.class) {
-        elements.push(
-          span({className: "attr-name theme-fg-color2"},
-            attributes.class
-              .replace(/(^\s+)|(\s+$)/g, "")
-              .split(" ")
-              .map(cls => `.${cls}`)
-              .join("")
-          )
-        );
-      }
-      return elements;
-    }
-    let attributeElements = Object.keys(attributes)
-      .sort(function getIdAndClassFirst(a1, a2) {
-        if ([a1, a2].includes("id")) {
-          return 3 * (a1 === "id" ? -1 : 1);
-        }
-        if ([a1, a2].includes("class")) {
-          return 2 * (a1 === "class" ? -1 : 1);
-        }
-
-        // `id` and `class` excepted,
-        // we want to keep the same order that in `attributes`.
-        return 0;
-      })
-      .reduce((arr, name, i, keys) => {
-        let value = attributes[name];
-        let attribute = span({},
-          span({className: "attr-name theme-fg-color2"}, `${name}`),
-          `="`,
-          span({className: "attr-value theme-fg-color6"}, `${value}`),
-          `"`
-        );
-
-        return arr.concat([" ", attribute]);
-      }, []);
-
-    return [
-      "<",
-      nodeNameElement,
-      ...attributeElements,
-      ">",
-    ];
-  },
-
-  render: wrapRender(function () {
-    let {
-      object,
-      mode,
-      attachedActorIds,
-      onDOMNodeMouseOver,
-      onDOMNodeMouseOut,
-      onInspectIconClick,
-    } = this.props;
-    let elements = this.getElements(object, mode);
-    let objectLink = (config, ...children) => {
-      if (this.props.objectLink) {
-        return this.props.objectLink(Object.assign({object}, config), ...children);
-      }
-      return span(config, ...children);
-    };
-
-    let isInTree = attachedActorIds ? attachedActorIds.includes(object.actor) : true;
-
-    let baseConfig = {className: "objectBox objectBox-node"};
-    let inspectIcon;
-    if (isInTree) {
-      if (onDOMNodeMouseOver) {
-        Object.assign(baseConfig, {
-          onMouseOver: _ => onDOMNodeMouseOver(object)
-        });
-      }
-
-      if (onDOMNodeMouseOut) {
-        Object.assign(baseConfig, {
-          onMouseOut: onDOMNodeMouseOut
-        });
-      }
-
-      if (onInspectIconClick) {
-        inspectIcon = Svg("open-inspector", {
-          element: "a",
-          draggable: false,
-          // TODO: Localize this with "openNodeInInspector" when Bug 1317038 lands
-          title: "Click to select the node in the inspector",
-          onClick: (e) => onInspectIconClick(object, e)
-        });
-      }
+  let baseConfig = {className: "objectBox objectBox-node"};
+  let inspectIcon;
+  if (isInTree) {
+    if (onDOMNodeMouseOver) {
+      Object.assign(baseConfig, {
+        onMouseOver: _ => onDOMNodeMouseOver(object)
+      });
     }
 
-    return span(baseConfig,
-      objectLink({}, ...elements),
-      inspectIcon
-    );
-  }),
-});
+    if (onDOMNodeMouseOut) {
+      Object.assign(baseConfig, {
+        onMouseOut: onDOMNodeMouseOut
+      });
+    }
+
+    if (onInspectIconClick) {
+      inspectIcon = Svg("open-inspector", {
+        element: "a",
+        draggable: false,
+        // TODO: Localize this with "openNodeInInspector" when Bug 1317038 lands
+        title: "Click to select the node in the inspector",
+        onClick: (e) => onInspectIconClick(object, e)
+      });
+    }
+  }
+
+  return span(baseConfig,
+    safeObjectLink(props, {}, ...elements),
+    inspectIcon
+  );
+}
+
+function getElements(grip, mode) {
+  let {attributes, nodeName} = grip.preview;
+  const nodeNameElement = span({
+    className: "tag-name theme-fg-color3"
+  }, nodeName);
+
+  if (mode === MODE.TINY) {
+    let elements = [nodeNameElement];
+    if (attributes.id) {
+      elements.push(
+        span({className: "attr-name theme-fg-color2"}, `#${attributes.id}`));
+    }
+    if (attributes.class) {
+      elements.push(
+        span({className: "attr-name theme-fg-color2"},
+          attributes.class
+            .replace(/(^\s+)|(\s+$)/g, "")
+            .split(" ")
+            .map(cls => `.${cls}`)
+            .join("")
+        )
+      );
+    }
+    return elements;
+  }
+  let attributeElements = Object.keys(attributes)
+    .sort(function getIdAndClassFirst(a1, a2) {
+      if ([a1, a2].includes("id")) {
+        return 3 * (a1 === "id" ? -1 : 1);
+      }
+      if ([a1, a2].includes("class")) {
+        return 2 * (a1 === "class" ? -1 : 1);
+      }
+
+      // `id` and `class` excepted,
+      // we want to keep the same order that in `attributes`.
+      return 0;
+    })
+    .reduce((arr, name, i, keys) => {
+      let value = attributes[name];
+      let attribute = span({},
+        span({className: "attr-name theme-fg-color2"}, `${name}`),
+        `="`,
+        span({className: "attr-value theme-fg-color6"}, `${value}`),
+        `"`
+      );
+
+      return arr.concat([" ", attribute]);
+    }, []);
+
+  return [
+    "<",
+    nodeNameElement,
+    ...attributeElements,
+    ">",
+  ];
+}
 
 // Registration
 function supportsObject(object, type) {
@@ -150,6 +141,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: ElementNode,
-  supportsObject: supportsObject
+  rep: wrapRender(ElementNode),
+  supportsObject,
 };

--- a/src/reps/error.js
+++ b/src/reps/error.js
@@ -3,55 +3,43 @@ const React = require("react");
 // Utils
 const {
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 const { MODE } = require("./constants");
-// Shortcuts
-const { span } = React.DOM;
 
 /**
  * Renders Error objects.
  */
-const ErrorRep = React.createClass({
-  displayName: "Error",
+ErrorRep.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    objectLink: React.PropTypes.func,
-  },
+function ErrorRep(props) {
+  let object = props.object;
+  let preview = object.preview;
+  let name = preview && preview.name
+    ? preview.name
+    : "Error";
 
-  render: wrapRender(function () {
-    let object = this.props.object;
-    let preview = object.preview;
-    let name = preview && preview.name
-      ? preview.name
-      : "Error";
+  let content = props.mode === MODE.TINY
+    ? name
+    : `${name}: ${preview.message}`;
 
-    let content = this.props.mode === MODE.TINY
-      ? name
-      : `${name}: ${preview.message}`;
+  if (preview.stack && props.mode !== MODE.TINY) {
+    /*
+      * Since Reps are used in the JSON Viewer, we can't localize
+      * the "Stack trace" label (defined in debugger.properties as
+      * "variablesViewErrorStacktrace" property), until Bug 1317038 lands.
+      */
+    content = `${content}\nStack trace:\n${preview.stack}`;
+  }
 
-    if (preview.stack && this.props.mode !== MODE.TINY) {
-      /*
-       * Since Reps are used in the JSON Viewer, we can't localize
-       * the "Stack trace" label (defined in debugger.properties as
-       * "variablesViewErrorStacktrace" property), until Bug 1317038 lands.
-       */
-      content = `${content}\nStack trace:\n${preview.stack}`;
-    }
-
-    let objectLink = (config, ...children) => {
-      if (this.props.objectLink) {
-        return this.props.objectLink(Object.assign({object}, config), ...children);
-      }
-      return span(config, ...children);
-    };
-
-    return objectLink({className: "objectBox-stackTrace"}, content);
-  }),
-});
+  return safeObjectLink(props, {className: "objectBox-stackTrace"}, content);
+}
 
 // Registration
 function supportsObject(object, type) {
@@ -63,6 +51,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: ErrorRep,
-  supportsObject: supportsObject
+  rep: wrapRender(ErrorRep),
+  supportsObject,
 };

--- a/src/reps/function.js
+++ b/src/reps/function.js
@@ -5,6 +5,7 @@ const React = require("react");
 const {
   isGrip,
   cropString,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 
@@ -14,53 +15,42 @@ const { span } = React.DOM;
 /**
  * This component represents a template for Function objects.
  */
-let Func = React.createClass({
-  displayName: "Func",
+FunctionRep.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function FunctionRep(props) {
+  let grip = props.object;
 
-  getTitle: function (grip) {
-    let title = "function ";
-    if (grip.isGenerator) {
-      title = "function* ";
-    }
-    if (grip.isAsync) {
-      title = "async " + title;
-    }
+  return (
+    // Set dir="ltr" to prevent function parentheses from
+    // appearing in the wrong direction
+    span({dir: "ltr", className: "objectBox objectBox-function"},
+      getTitle(props, grip),
+      summarizeFunction(grip)
+    )
+  );
+}
 
-    if (this.props.objectLink) {
-      return this.props.objectLink({
-        object: grip
-      }, title);
-    }
+function getTitle(props, grip) {
+  let title = "function ";
+  if (grip.isGenerator) {
+    title = "function* ";
+  }
+  if (grip.isAsync) {
+    title = "async " + title;
+  }
 
-    return title;
-  },
+  return safeObjectLink(props, {}, title);
+}
 
-  summarizeFunction: function (grip) {
-    let name = grip.userDisplayName || grip.displayName || grip.name || "";
-    return cropString(name + "()", 100);
-  },
-
-  render: wrapRender(function () {
-    let grip = this.props.object;
-
-    return (
-      // Set dir="ltr" to prevent function parentheses from
-      // appearing in the wrong direction
-      span({dir: "ltr", className: "objectBox objectBox-function"},
-        this.getTitle(grip),
-        this.summarizeFunction(grip)
-      )
-    );
-  }),
-});
+function summarizeFunction(grip) {
+  let name = grip.userDisplayName || grip.displayName || grip.name || "";
+  return cropString(name + "()", 100);
+}
 
 // Registration
-
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
     return (type == "function");
@@ -72,6 +62,6 @@ function supportsObject(grip, type) {
 // Exports from this module
 
 module.exports = {
-  rep: Func,
-  supportsObject: supportsObject
+  rep: wrapRender(FunctionRep),
+  supportsObject,
 };

--- a/src/reps/grip-array.js
+++ b/src/reps/grip-array.js
@@ -1,11 +1,11 @@
 // Dependencies
 const React = require("react");
 const {
-  createFactories,
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-const Caption = React.createFactory(require("./caption"));
+const Caption = require("./caption");
 const { MODE } = require("./constants");
 
 // Shortcuts
@@ -15,195 +15,176 @@ const { span } = React.DOM;
  * Renders an array. The array is enclosed by left and right bracket
  * and the max number of rendered items depends on the current mode.
  */
-let GripArray = React.createClass({
-  displayName: "GripArray",
+GripArray.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  provider: React.PropTypes.object,
+  objectLink: React.PropTypes.func,
+  attachedActorIds: React.PropTypes.array,
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    provider: React.PropTypes.object,
-    objectLink: React.PropTypes.func,
-    attachedActorIds: React.PropTypes.array,
-    onDOMNodeMouseOver: React.PropTypes.func,
-    onDOMNodeMouseOut: React.PropTypes.func,
-    onInspectIconClick: React.PropTypes.func,
-  },
+function GripArray(props) {
+  let {
+    object,
+    mode = MODE.SHORT
+  } = props;
 
-  getLength: function (grip) {
-    if (!grip.preview) {
-      return 0;
-    }
+  let items;
+  let brackets;
+  let needSpace = function (space) {
+    return space ? { left: "[ ", right: " ]"} : { left: "[", right: "]"};
+  };
 
-    return grip.preview.length || grip.preview.childNodesLength || 0;
-  },
+  if (mode === MODE.TINY) {
+    let objectLength = getLength(object);
+    let isEmpty = objectLength === 0;
+    items = [span({className: "length"}, isEmpty ? "" : objectLength)];
+    brackets = needSpace(false);
+  } else {
+    let max = (mode === MODE.SHORT) ? 3 : 10;
+    items = arrayIterator(props, object, max);
+    brackets = needSpace(items.length > 0);
+  }
 
-  getTitle: function (object, context) {
-    if (this.props.mode === MODE.TINY) {
-      return "";
-    }
+  let title = getTitle(props, object);
 
-    let title = this.props.title || object.class || "Array";
-    return this.safeObjectLink({}, title + " ");
-  },
-
-  getPreviewItems: function (grip) {
-    if (!grip.preview) {
-      return null;
-    }
-
-    return grip.preview.items || grip.preview.childNodes || null;
-  },
-
-  arrayIterator: function (grip, max) {
-    let items = [];
-    const gripLength = this.getLength(grip);
-
-    if (!gripLength) {
-      return items;
-    }
-
-    const previewItems = this.getPreviewItems(grip);
-    if (!previewItems) {
-      return items;
-    }
-
-    let delim;
-    // number of grip preview items is limited to 10, but we may have more
-    // items in grip-array.
-    let delimMax = gripLength > previewItems.length ?
-      previewItems.length : previewItems.length - 1;
-    let provider = this.props.provider;
-
-    for (let i = 0; i < previewItems.length && i < max; i++) {
-      try {
-        let itemGrip = previewItems[i];
-        let value = provider ? provider.getValue(itemGrip) : itemGrip;
-
-        delim = (i == delimMax ? "" : ", ");
-
-        items.push(GripArrayItem(Object.assign({}, this.props, {
-          object: value,
-          delim: delim,
-          // Do not propagate title to array items reps
-          title: undefined,
-        })));
-      } catch (exc) {
-        items.push(GripArrayItem(Object.assign({}, this.props, {
-          object: exc,
-          delim: delim,
-          // Do not propagate title to array items reps
-          title: undefined,
-        })));
-      }
-    }
-    if (previewItems.length > max || gripLength > previewItems.length) {
-      let leftItemNum = gripLength - max > 0 ?
-        gripLength - max : gripLength - previewItems.length;
-      items.push(Caption({
-        object: this.safeObjectLink({}, leftItemNum + " more…")
-      }));
-    }
-
-    return items;
-  },
-
-  safeObjectLink: function (config, ...children) {
-    if (this.props.objectLink) {
-      return this.props.objectLink(Object.assign({
-        object: this.props.object
-      }, config), ...children);
-    }
-
-    if (Object.keys(config).length === 0 && children.length === 1) {
-      return children[0];
-    }
-
-    return span(config, ...children);
-  },
-
-  render: wrapRender(function () {
-    let {
-      object,
-      mode = MODE.SHORT
-    } = this.props;
-
-    let items;
-    let brackets;
-    let needSpace = function (space) {
-      return space ? { left: "[ ", right: " ]"} : { left: "[", right: "]"};
-    };
-
-    if (mode === MODE.TINY) {
-      let objectLength = this.getLength(object);
-      let isEmpty = objectLength === 0;
-      items = [span({className: "length"}, isEmpty ? "" : objectLength)];
-      brackets = needSpace(false);
-    } else {
-      let max = (mode === MODE.SHORT) ? 3 : 10;
-      items = this.arrayIterator(object, max);
-      brackets = needSpace(items.length > 0);
-    }
-
-    let title = this.getTitle(object);
-
-    return (
+  return (
+    span({
+      className: "objectBox objectBox-array"},
+      title,
+      safeObjectLink(props, {
+        className: "arrayLeftBracket",
+      }, brackets.left),
+      ...items,
+      safeObjectLink(props, {
+        className: "arrayRightBracket",
+      }, brackets.right),
       span({
-        className: "objectBox objectBox-array"},
-        title,
-        this.safeObjectLink({
-          className: "arrayLeftBracket",
-        }, brackets.left),
-        ...items,
-        this.safeObjectLink({
-          className: "arrayRightBracket",
-        }, brackets.right),
-        span({
-          className: "arrayProperties",
-          role: "group"}
-        )
+        className: "arrayProperties",
+        role: "group"}
       )
-    );
-  }),
-});
+    )
+  );
+}
 
 /**
  * Renders array item. Individual values are separated by
  * a delimiter (a comma by default).
  */
-let GripArrayItem = React.createFactory(React.createClass({
-  displayName: "GripArrayItem",
+GripArrayItem.propTypes = {
+  delim: React.PropTypes.string,
+  object: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.number,
+    React.PropTypes.string,
+  ]).isRequired,
+  objectLink: React.PropTypes.func,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  provider: React.PropTypes.object,
+  attachedActorIds: React.PropTypes.array,
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+};
 
-  propTypes: {
-    delim: React.PropTypes.string,
-    object: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.number,
-      React.PropTypes.string,
-    ]).isRequired,
-    objectLink: React.PropTypes.func,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    provider: React.PropTypes.object,
-    attachedActorIds: React.PropTypes.array,
-    onDOMNodeMouseOver: React.PropTypes.func,
-    onDOMNodeMouseOut: React.PropTypes.func,
-    onInspectIconClick: React.PropTypes.func,
-  },
+function GripArrayItem(props) {
+  let { Rep } = require("./rep");
+  let {
+    delim,
+  } = props;
 
-  render: function () {
-    let { Rep } = createFactories(require("./rep"));
+  return (
+    span({},
+      Rep(Object.assign({}, props, {
+        mode: MODE.TINY
+      })),
+      delim
+    )
+  );
+}
 
-    return (
-      span({},
-        Rep(Object.assign({}, this.props, {
-          mode: MODE.TINY
-        })),
-        this.props.delim
-      )
-    );
+function getLength(grip) {
+  if (!grip.preview) {
+    return 0;
   }
-}));
+
+  return grip.preview.length || grip.preview.childNodesLength || 0;
+}
+
+function getTitle(props, object, context) {
+  if (props.mode === MODE.TINY) {
+    return "";
+  }
+
+  let title = props.title || object.class || "Array";
+  return safeObjectLink(props, {}, title + " ");
+}
+
+function getPreviewItems(grip) {
+  if (!grip.preview) {
+    return null;
+  }
+
+  return grip.preview.items || grip.preview.childNodes || null;
+}
+
+function arrayIterator(props, grip, max) {
+  let items = [];
+  const gripLength = getLength(grip);
+
+  if (!gripLength) {
+    return items;
+  }
+
+  const previewItems = getPreviewItems(grip);
+  if (!previewItems) {
+    return items;
+  }
+
+  let delim;
+  // number of grip preview items is limited to 10, but we may have more
+  // items in grip-array.
+  let delimMax = gripLength > previewItems.length ?
+    previewItems.length : previewItems.length - 1;
+  let provider = props.provider;
+
+  for (let i = 0; i < previewItems.length && i < max; i++) {
+    try {
+      let itemGrip = previewItems[i];
+      let value = provider ? provider.getValue(itemGrip) : itemGrip;
+
+      delim = (i == delimMax ? "" : ", ");
+
+      items.push(GripArrayItem(Object.assign({}, props, {
+        object: value,
+        delim: delim,
+        // Do not propagate title to array items reps
+        title: undefined,
+      })));
+    } catch (exc) {
+      items.push(GripArrayItem(Object.assign({}, props, {
+        object: exc,
+        delim: delim,
+        // Do not propagate title to array items reps
+        title: undefined,
+      })));
+    }
+  }
+  if (previewItems.length > max || gripLength > previewItems.length) {
+    let leftItemNum = gripLength - max > 0 ?
+      gripLength - max : gripLength - previewItems.length;
+    items.push(Caption({
+      object: safeObjectLink(props, {}, leftItemNum + " more…")
+    }));
+  }
+
+  return items;
+}
 
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
@@ -219,6 +200,6 @@ function supportsObject(grip, type) {
 
 // Exports from this module
 module.exports = {
-  rep: GripArray,
-  supportsObject: supportsObject
+  rep: wrapRender(GripArray),
+  supportsObject,
 };

--- a/src/reps/grip.js
+++ b/src/reps/grip.js
@@ -2,12 +2,12 @@
 const React = require("react");
 // Dependencies
 const {
-  createFactories,
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-const Caption = React.createFactory(require("./caption"));
-const PropRep = React.createFactory(require("./prop-rep"));
+const Caption = require("./caption");
+const PropRep = require("./prop-rep");
 const { MODE } = require("./constants");
 // Shortcuts
 const { span } = React.DOM;
@@ -17,231 +17,214 @@ const { span } = React.DOM;
  * of remote JS object and is used as an input object
  * for this rep component.
  */
-const GripRep = React.createClass({
-  displayName: "Grip",
+GripRep.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  isInterestingProp: React.PropTypes.func,
+  title: React.PropTypes.string,
+  objectLink: React.PropTypes.func,
+  attachedActorIds: React.PropTypes.array,
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    isInterestingProp: React.PropTypes.func,
-    title: React.PropTypes.string,
-    objectLink: React.PropTypes.func,
-    attachedActorIds: React.PropTypes.array,
-    onDOMNodeMouseOver: React.PropTypes.func,
-    onDOMNodeMouseOut: React.PropTypes.func,
-    onInspectIconClick: React.PropTypes.func,
-  },
+function GripRep(props) {
+  let object = props.object;
+  let propsArray = safePropIterator(props, object,
+    (props.mode === MODE.LONG) ? 10 : 3);
 
-  getTitle: function (object) {
-    let title = this.props.title || object.class || "Object";
-    return this.safeObjectLink({}, title);
-  },
-
-  safePropIterator: function (object, max) {
-    max = (typeof max === "undefined") ? 3 : max;
-    try {
-      return this.propIterator(object, max);
-    } catch (err) {
-      console.error(err);
-    }
-    return [];
-  },
-
-  propIterator: function (object, max) {
-    if (object.preview && Object.keys(object.preview).includes("wrappedValue")) {
-      const { Rep } = createFactories(require("./rep"));
-
-      return [Rep({
-        object: object.preview.wrappedValue,
-        mode: this.props.mode || MODE.TINY,
-        defaultRep: Grip,
-      })];
-    }
-
-    // Property filter. Show only interesting properties to the user.
-    let isInterestingProp = this.props.isInterestingProp || ((type, value) => {
-      return (
-        type == "boolean" ||
-        type == "number" ||
-        (type == "string" && value.length != 0)
-      );
-    });
-
-    let properties = object.preview
-      ? object.preview.ownProperties
-      : {};
-    let propertiesLength = object.preview && object.preview.ownPropertiesLength
-      ? object.preview.ownPropertiesLength
-      : object.ownPropertyLength;
-
-    if (object.preview && object.preview.safeGetterValues) {
-      properties = Object.assign({}, properties, object.preview.safeGetterValues);
-      propertiesLength += Object.keys(object.preview.safeGetterValues).length;
-    }
-
-    let indexes = this.getPropIndexes(properties, max, isInterestingProp);
-    if (indexes.length < max && indexes.length < propertiesLength) {
-      // There are not enough props yet. Then add uninteresting props to display them.
-      indexes = indexes.concat(
-        this.getPropIndexes(properties, max - indexes.length, (t, value, name) => {
-          return !isInterestingProp(t, value, name);
-        })
-      );
-    }
-
-    const truncate = Object.keys(properties).length > max;
-    // The server synthesizes some property names for a Proxy, like
-    // <target> and <handler>; we don't want to quote these because,
-    // as synthetic properties, they appear more natural when
-    // unquoted.
-    const suppressQuotes = object.class === "Proxy";
-    let propsArray = this.getProps(properties, indexes, truncate, suppressQuotes);
-    if (truncate) {
-      // There are some undisplayed props. Then display "more...".
-      propsArray.push(Caption({
-        object: this.safeObjectLink({}, `${propertiesLength - max} more…`)
-      }));
-    }
-
-    return propsArray;
-  },
-
-  /**
-   * Get props ordered by index.
-   *
-   * @param {Object} properties Props object.
-   * @param {Array} indexes Indexes of props.
-   * @param {Boolean} truncate true if the grip will be truncated.
-   * @param {Boolean} suppressQuotes true if we should suppress quotes
-   *                  on property names.
-   * @return {Array} Props.
-   */
-  getProps: function (properties, indexes, truncate, suppressQuotes) {
-    let propsArray = [];
-
-    // Make indexes ordered by ascending.
-    indexes.sort(function (a, b) {
-      return a - b;
-    });
-
-    indexes.forEach((i) => {
-      let name = Object.keys(properties)[i];
-      let value = this.getPropValue(properties[name]);
-
-      let propRepProps = Object.assign({}, this.props, {
-        mode: MODE.TINY,
-        name: name,
-        object: value,
-        equal: ": ",
-        delim: i !== indexes.length - 1 || truncate ? ", " : "",
-        defaultRep: Grip,
-        // Do not propagate title to properties reps
-        title: undefined,
-        suppressQuotes,
-      });
-      delete propRepProps.objectLink;
-      propsArray.push(PropRep(propRepProps));
-    });
-
-    return propsArray;
-  },
-
-  /**
-   * Get the indexes of props in the object.
-   *
-   * @param {Object} properties Props object.
-   * @param {Number} max The maximum length of indexes array.
-   * @param {Function} filter Filter the props you want.
-   * @return {Array} Indexes of interesting props in the object.
-   */
-  getPropIndexes: function (properties, max, filter) {
-    let indexes = [];
-
-    try {
-      let i = 0;
-      for (let name in properties) {
-        if (indexes.length >= max) {
-          return indexes;
-        }
-
-        // Type is specified in grip's "class" field and for primitive
-        // values use typeof.
-        let value = this.getPropValue(properties[name]);
-        let type = (value.class || typeof value);
-        type = type.toLowerCase();
-
-        if (filter(type, value, name)) {
-          indexes.push(i);
-        }
-        i++;
-      }
-    } catch (err) {
-      console.error(err);
-    }
-    return indexes;
-  },
-
-  /**
-   * Get the actual value of a property.
-   *
-   * @param {Object} property
-   * @return {Object} Value of the property.
-   */
-  getPropValue: function (property) {
-    let value = property;
-    if (typeof property === "object") {
-      let keys = Object.keys(property);
-      if (keys.includes("value")) {
-        value = property.value;
-      } else if (keys.includes("getterValue")) {
-        value = property.getterValue;
-      }
-    }
-    return value;
-  },
-
-  safeObjectLink: function (config, ...children) {
-    if (this.props.objectLink) {
-      return this.props.objectLink(Object.assign({
-        object: this.props.object
-      }, config), ...children);
-    }
-
-    if (Object.keys(config).length === 0 && children.length === 1) {
-      return children[0];
-    }
-
-    return span(config, ...children);
-  },
-
-  render: wrapRender(function () {
-    let object = this.props.object;
-    let propsArray = this.safePropIterator(object,
-      (this.props.mode === MODE.LONG) ? 10 : 3);
-
-    if (this.props.mode === MODE.TINY) {
-      return (
-        span({className: "objectBox objectBox-object"},
-          this.getTitle(object)
-        )
-      );
-    }
-
+  if (props.mode === MODE.TINY) {
     return (
       span({className: "objectBox objectBox-object"},
-        this.getTitle(object),
-        this.safeObjectLink({
-          className: "objectLeftBrace",
-        }, " { "),
-        ...propsArray,
-        this.safeObjectLink({
-          className: "objectRightBrace",
-        }, " }")
+        getTitle(props, object)
       )
     );
-  }),
-});
+  }
+
+  return (
+    span({className: "objectBox objectBox-object"},
+      getTitle(props, object),
+      safeObjectLink(props, {
+        className: "objectLeftBrace",
+      }, " { "),
+      ...propsArray,
+      safeObjectLink(props, {
+        className: "objectRightBrace",
+      }, " }")
+    )
+  );
+}
+
+function getTitle(props, object) {
+  let title = props.title || object.class || "Object";
+  return safeObjectLink(props, {}, title);
+}
+
+function safePropIterator(props, object, max) {
+  max = (typeof max === "undefined") ? 3 : max;
+  try {
+    return propIterator(props, object, max);
+  } catch (err) {
+    console.error(err);
+  }
+  return [];
+}
+
+function propIterator(props, object, max) {
+  if (object.preview && Object.keys(object.preview).includes("wrappedValue")) {
+    const { Rep } = require("./rep");
+
+    return [Rep({
+      object: object.preview.wrappedValue,
+      mode: props.mode || MODE.TINY,
+      defaultRep: Grip,
+    })];
+  }
+
+  // Property filter. Show only interesting properties to the user.
+  let isInterestingProp = props.isInterestingProp || ((type, value) => {
+    return (
+      type == "boolean" ||
+      type == "number" ||
+      (type == "string" && value.length != 0)
+    );
+  });
+
+  let properties = object.preview
+    ? object.preview.ownProperties
+    : {};
+  let propertiesLength = object.preview && object.preview.ownPropertiesLength
+    ? object.preview.ownPropertiesLength
+    : object.ownPropertyLength;
+
+  if (object.preview && object.preview.safeGetterValues) {
+    properties = Object.assign({}, properties, object.preview.safeGetterValues);
+    propertiesLength += Object.keys(object.preview.safeGetterValues).length;
+  }
+
+  let indexes = getPropIndexes(properties, max, isInterestingProp);
+  if (indexes.length < max && indexes.length < propertiesLength) {
+    // There are not enough props yet. Then add uninteresting props to display them.
+    indexes = indexes.concat(
+      getPropIndexes(properties, max - indexes.length, (t, value, name) => {
+        return !isInterestingProp(t, value, name);
+      })
+    );
+  }
+
+  const truncate = Object.keys(properties).length > max;
+  // The server synthesizes some property names for a Proxy, like
+  // <target> and <handler>; we don't want to quote these because,
+  // as synthetic properties, they appear more natural when
+  // unquoted.
+  const suppressQuotes = object.class === "Proxy";
+  let propsArray = getProps(props, properties, indexes, truncate, suppressQuotes);
+  if (truncate) {
+    // There are some undisplayed props. Then display "more...".
+    propsArray.push(Caption({
+      object: safeObjectLink(props, {}, `${propertiesLength - max} more…`)
+    }));
+  }
+
+  return propsArray;
+}
+
+/**
+ * Get props ordered by index.
+ *
+ * @param {Object} componentProps Grip Component props.
+ * @param {Object} properties Properties of the object the Grip describes.
+ * @param {Array} indexes Indexes of properties.
+ * @param {Boolean} truncate true if the grip will be truncated.
+ * @param {Boolean} suppressQuotes true if we should suppress quotes
+ *                  on property names.
+ * @return {Array} Props.
+ */
+function getProps(componentProps, properties, indexes, truncate, suppressQuotes) {
+  let propsArray = [];
+
+  // Make indexes ordered by ascending.
+  indexes.sort(function (a, b) {
+    return a - b;
+  });
+
+  indexes.forEach((i) => {
+    let name = Object.keys(properties)[i];
+    let value = getPropValue(properties[name]);
+
+    let propRepProps = Object.assign({}, componentProps, {
+      mode: MODE.TINY,
+      name: name,
+      object: value,
+      equal: ": ",
+      delim: i !== indexes.length - 1 || truncate ? ", " : "",
+      defaultRep: Grip,
+      // Do not propagate title to properties reps
+      title: undefined,
+      suppressQuotes,
+    });
+    delete propRepProps.objectLink;
+    propsArray.push(PropRep(propRepProps));
+  });
+
+  return propsArray;
+}
+
+/**
+ * Get the indexes of props in the object.
+ *
+ * @param {Object} properties Props object.
+ * @param {Number} max The maximum length of indexes array.
+ * @param {Function} filter Filter the props you want.
+ * @return {Array} Indexes of interesting props in the object.
+ */
+function getPropIndexes(properties, max, filter) {
+  let indexes = [];
+
+  try {
+    let i = 0;
+    for (let name in properties) {
+      if (indexes.length >= max) {
+        return indexes;
+      }
+
+      // Type is specified in grip's "class" field and for primitive
+      // values use typeof.
+      let value = getPropValue(properties[name]);
+      let type = (value.class || typeof value);
+      type = type.toLowerCase();
+
+      if (filter(type, value, name)) {
+        indexes.push(i);
+      }
+      i++;
+    }
+  } catch (err) {
+    console.error(err);
+  }
+  return indexes;
+}
+
+/**
+ * Get the actual value of a property.
+ *
+ * @param {Object} property
+ * @return {Object} Value of the property.
+ */
+function getPropValue(property) {
+  let value = property;
+  if (typeof property === "object") {
+    let keys = Object.keys(property);
+    if (keys.includes("value")) {
+      value = property.value;
+    } else if (keys.includes("getterValue")) {
+      value = property.getterValue;
+    }
+  }
+  return value;
+}
 
 // Registration
 function supportsObject(object, type) {
@@ -253,8 +236,8 @@ function supportsObject(object, type) {
 
 // Grip is used in propIterator and has to be defined here.
 let Grip = {
-  rep: GripRep,
-  supportsObject: supportsObject
+  rep: wrapRender(GripRep),
+  supportsObject,
 };
 
 // Exports from this module

--- a/src/reps/infinity.js
+++ b/src/reps/infinity.js
@@ -9,21 +9,17 @@ const { span } = React.DOM;
 /**
  * Renders a Infinity object
  */
-const InfinityRep = React.createClass({
-  displayName: "Infinity",
+InfinityRep.propTypes = {
+  object: React.PropTypes.object.isRequired,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-  },
-
-  render: wrapRender(function () {
-    return (
-      span({className: "objectBox objectBox-number"},
-        this.props.object.type
-      )
-    );
-  })
-});
+function InfinityRep(props) {
+  return (
+    span({className: "objectBox objectBox-number"},
+      props.object.type
+    )
+  );
+}
 
 function supportsObject(object, type) {
   return type == "Infinity" || type == "-Infinity";
@@ -31,6 +27,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: InfinityRep,
-  supportsObject: supportsObject
+  rep: wrapRender(InfinityRep),
+  supportsObject,
 };

--- a/src/reps/long-string.js
+++ b/src/reps/long-string.js
@@ -12,49 +12,39 @@ const { span } = React.DOM;
 /**
  * Renders a long string grip.
  */
-const LongStringRep = React.createClass({
-  displayName: "LongStringRep",
+LongStringRep.propTypes = {
+  useQuotes: React.PropTypes.bool,
+  style: React.PropTypes.object,
+  cropLimit: React.PropTypes.number.isRequired,
+  member: React.PropTypes.string,
+  object: React.PropTypes.object.isRequired,
+};
 
-  propTypes: {
-    useQuotes: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    cropLimit: React.PropTypes.number.isRequired,
-    member: React.PropTypes.string,
-    object: React.PropTypes.object.isRequired,
-  },
+function LongStringRep(props) {
+  let {
+    cropLimit,
+    member,
+    object,
+    style,
+    useQuotes = true
+  } = props;
+  let {fullText, initial, length} = object;
 
-  getDefaultProps: function () {
-    return {
-      useQuotes: true,
-    };
-  },
+  let config = {className: "objectBox objectBox-string"};
+  if (style) {
+    config.style = style;
+  }
 
-  render: wrapRender(function () {
-    let {
-      cropLimit,
-      member,
-      object,
-      style,
-      useQuotes
-    } = this.props;
-    let {fullText, initial, length} = object;
+  let string = member && member.open
+    ? fullText || initial
+    : initial.substring(0, cropLimit);
 
-    let config = {className: "objectBox objectBox-string"};
-    if (style) {
-      config.style = style;
-    }
-
-    let string = member && member.open
-      ? fullText || initial
-      : initial.substring(0, cropLimit);
-
-    if (string.length < length) {
-      string += "\u2026";
-    }
-    let formattedString = useQuotes ? escapeString(string) : sanitizeString(string);
-    return span(config, formattedString);
-  }),
-});
+  if (string.length < length) {
+    string += "\u2026";
+  }
+  let formattedString = useQuotes ? escapeString(string) : sanitizeString(string);
+  return span(config, formattedString);
+}
 
 function supportsObject(object, type) {
   if (!isGrip(object)) {
@@ -65,6 +55,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: LongStringRep,
-  supportsObject: supportsObject,
+  rep: wrapRender(LongStringRep),
+  supportsObject,
 };

--- a/src/reps/nan.js
+++ b/src/reps/nan.js
@@ -9,17 +9,13 @@ const { span } = React.DOM;
 /**
  * Renders a NaN object
  */
-const NaNRep = React.createClass({
-  displayName: "NaN",
-
-  render: wrapRender(function () {
-    return (
-      span({className: "objectBox objectBox-nan"},
-        "NaN"
-      )
-    );
-  })
-});
+function NaNRep(props) {
+  return (
+    span({className: "objectBox objectBox-nan"},
+      "NaN"
+    )
+  );
+}
 
 function supportsObject(object, type) {
   return type == "NaN";
@@ -27,6 +23,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: NaNRep,
-  supportsObject: supportsObject
+  rep: wrapRender(NaNRep),
+  supportsObject,
 };

--- a/src/reps/null.js
+++ b/src/reps/null.js
@@ -9,17 +9,13 @@ const { span } = React.DOM;
 /**
  * Renders null value
  */
-const Null = React.createClass({
-  displayName: "NullRep",
-
-  render: wrapRender(function () {
-    return (
-      span({className: "objectBox objectBox-null"},
-        "null"
-      )
-    );
-  }),
-});
+function Null(props) {
+  return (
+    span({className: "objectBox objectBox-null"},
+      "null"
+    )
+  );
+}
 
 function supportsObject(object, type) {
   if (object && object.type && object.type == "null") {
@@ -32,6 +28,6 @@ function supportsObject(object, type) {
 // Exports from this module
 
 module.exports = {
-  rep: Null,
-  supportsObject: supportsObject
+  rep: wrapRender(Null),
+  supportsObject,
 };

--- a/src/reps/number.js
+++ b/src/reps/number.js
@@ -9,34 +9,30 @@ const { span } = React.DOM;
 /**
  * Renders a number
  */
-const Number = React.createClass({
-  displayName: "Number",
+Number.propTypes = {
+  object: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.number,
+    React.PropTypes.bool,
+  ]).isRequired
+};
 
-  propTypes: {
-    object: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.number,
-      React.PropTypes.bool,
-    ]).isRequired
-  },
+function Number(props) {
+  let value = props.object;
 
-  stringify: function (object) {
-    let isNegativeZero = Object.is(object, -0) ||
-      (object.type && object.type == "-0");
+  return (
+    span({className: "objectBox objectBox-number"},
+      stringify(value)
+    )
+  );
+}
 
-    return (isNegativeZero ? "-0" : String(object));
-  },
+function stringify(object) {
+  let isNegativeZero = Object.is(object, -0) ||
+    (object.type && object.type == "-0");
 
-  render: wrapRender(function () {
-    let value = this.props.object;
-
-    return (
-      span({className: "objectBox objectBox-number"},
-        this.stringify(value)
-      )
-    );
-  })
-});
+  return (isNegativeZero ? "-0" : String(object));
+}
 
 function supportsObject(object, type) {
   return ["boolean", "number", "-0"].includes(type);
@@ -45,6 +41,6 @@ function supportsObject(object, type) {
 // Exports from this module
 
 module.exports = {
-  rep: Number,
-  supportsObject: supportsObject
+  rep: wrapRender(Number),
+  supportsObject,
 };

--- a/src/reps/object-with-text.js
+++ b/src/reps/object-with-text.js
@@ -13,48 +13,41 @@ const { span } = React.DOM;
 /**
  * Renders a grip object with textual data.
  */
-let ObjectWithText = React.createClass({
-  displayName: "ObjectWithText",
+ObjectWithText.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function ObjectWithText(props) {
+  let grip = props.object;
+  return (
+    span({className: "objectBox objectBox-" + getType(grip)},
+      getTitle(props, grip),
+      span({className: "objectPropValue"}, getDescription(grip))
+    )
+  );
+}
 
-  getTitle: function (grip) {
-    if (this.props.objectLink) {
-      return span({className: "objectBox"},
-        this.props.objectLink({
-          object: grip
-        }, this.getType(grip) + " ")
-      );
-    }
-    return "";
-  },
-
-  getType: function (grip) {
-    return grip.class;
-  },
-
-  getDescription: function (grip) {
-    return "\"" + grip.preview.text + "\"";
-  },
-
-  render: wrapRender(function () {
-    let grip = this.props.object;
-    return (
-      span({className: "objectBox objectBox-" + this.getType(grip)},
-        this.getTitle(grip),
-        span({className: "objectPropValue"},
-          this.getDescription(grip)
-        )
-      )
+function getTitle(props, grip) {
+  if (props.objectLink) {
+    return span({className: "objectBox"},
+      props.objectLink({
+        object: grip
+      }, getType(grip) + " ")
     );
-  }),
-});
+  }
+  return "";
+}
+
+function getType(grip) {
+  return grip.class;
+}
+
+function getDescription(grip) {
+  return "\"" + grip.preview.text + "\"";
+}
 
 // Registration
-
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
     return false;
@@ -65,6 +58,6 @@ function supportsObject(grip, type) {
 
 // Exports from this module
 module.exports = {
-  rep: ObjectWithText,
-  supportsObject: supportsObject
+  rep: wrapRender(ObjectWithText),
+  supportsObject,
 };

--- a/src/reps/object-with-url.js
+++ b/src/reps/object-with-url.js
@@ -5,6 +5,7 @@ const React = require("react");
 const {
   isGrip,
   getURLDisplayString,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
 
@@ -14,48 +15,34 @@ const { span } = React.DOM;
 /**
  * Renders a grip object with URL data.
  */
-let ObjectWithURL = React.createClass({
-  displayName: "ObjectWithURL",
+ObjectWithURL.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function ObjectWithURL(props) {
+  let grip = props.object;
+  return (
+    span({className: "objectBox objectBox-" + getType(grip)},
+      getTitle(props, grip),
+      span({className: "objectPropValue"}, getDescription(grip))
+    )
+  );
+}
 
-  getTitle: function (grip) {
-    if (this.props.objectLink) {
-      return span({className: "objectBox"},
-        this.props.objectLink({
-          object: grip
-        }, this.getType(grip) + " ")
-      );
-    }
-    return "";
-  },
+function getTitle(props, grip) {
+  return safeObjectLink(props, {className: "objectBox"}, getType(grip) + " ");
+}
 
-  getType: function (grip) {
-    return grip.class;
-  },
+function getType(grip) {
+  return grip.class;
+}
 
-  getDescription: function (grip) {
-    return getURLDisplayString(grip.preview.url);
-  },
-
-  render: wrapRender(function () {
-    let grip = this.props.object;
-    return (
-      span({className: "objectBox objectBox-" + this.getType(grip)},
-        this.getTitle(grip),
-        span({className: "objectPropValue"},
-          this.getDescription(grip)
-        )
-      )
-    );
-  }),
-});
+function getDescription(grip) {
+  return getURLDisplayString(grip.preview.url);
+}
 
 // Registration
-
 function supportsObject(grip, type) {
   if (!isGrip(grip)) {
     return false;
@@ -66,6 +53,6 @@ function supportsObject(grip, type) {
 
 // Exports from this module
 module.exports = {
-  rep: ObjectWithURL,
-  supportsObject: supportsObject
+  rep: wrapRender(ObjectWithURL),
+  supportsObject,
 };

--- a/src/reps/object.js
+++ b/src/reps/object.js
@@ -63,9 +63,9 @@ function safePropIterator(props, object, max) {
 }
 
 function propIterator(props, object, max) {
-  let isInterestingProp = (t, value) => {
+  let isInterestingProp = (type, value) => {
     // Do not pick objects, it could cause recursion.
-    return (t == "boolean" || t == "number" || (t == "string" && value));
+    return (type == "boolean" || type == "number" || (type == "string" && value));
   };
 
   // Work around https://bugzilla.mozilla.org/show_bug.cgi?id=945377
@@ -85,14 +85,14 @@ function propIterator(props, object, max) {
       getFilteredObject(
         object,
         max - Object.keys(interestingObject).length,
-        (t, value) => !isInterestingProp(t, value)
+        (type, value) => !isInterestingProp(type, value)
       )
     );
   }
 
-  const truncate = Object.keys(object).length > max;
-  let propsArray = getPropsArray(interestingObject, truncate);
-  if (truncate) {
+  const truncated = Object.keys(object).length > max;
+  let propsArray = getPropsArray(interestingObject, truncated);
+  if (truncated) {
     propsArray.push(Caption({
       object: safeObjectLink(props, {},
         (Object.keys(object).length - max) + " more…")
@@ -106,10 +106,10 @@ function propIterator(props, object, max) {
  * Get an array of components representing the properties of the object
  *
  * @param {Object} object
- * @param {Boolean} truncate true if the object will be truncated.
+ * @param {Boolean} truncated true if the object is truncated.
  * @return {Array} Array of PropRep.
  */
-function getPropsArray(object, truncate) {
+function getPropsArray(object, truncated) {
   let propsArray = [];
 
   if (!object) {
@@ -118,13 +118,13 @@ function getPropsArray(object, truncate) {
 
   // Hardcode tiny mode to avoid recursive handling.
   let mode = MODE.TINY;
-
-  return Object.keys(object).map((name, i) => PropRep({
+  const objectKeys = Object.keys(object);
+  return objectKeys.map((name, i) => PropRep({
     mode,
     name,
     object: object[name],
     equal: ": ",
-    delim: i !== Object.keys(object).length - 1 || truncate ? ", " : "",
+    delim: i !== objectKeys.length - 1 || truncated ? ", " : "",
   }));
 }
 

--- a/src/reps/object.js
+++ b/src/reps/object.js
@@ -1,10 +1,11 @@
 // Dependencies
 const React = require("react");
 const {
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-const Caption = React.createFactory(require("./caption"));
-const PropRep = React.createFactory(require("./prop-rep"));
+const Caption = require("./caption");
+const PropRep = require("./prop-rep");
 const { MODE } = require("./constants");
 // Shortcuts
 const { span } = React.DOM;
@@ -12,162 +13,162 @@ const { span } = React.DOM;
  * Renders an object. An object is represented by a list of its
  * properties enclosed in curly brackets.
  */
-const Obj = React.createClass({
-  displayName: "Obj",
+ObjectRep.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  objectLink: React.PropTypes.func,
+  title: React.PropTypes.string,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    objectLink: React.PropTypes.func,
-    title: React.PropTypes.string,
-  },
+function ObjectRep(props) {
+  let object = props.object;
+  let propsArray = safePropIterator(props, object);
 
-  getTitle: function (object) {
-    let title = this.props.title || object.class || "Object";
-    return this.safeObjectLink({className: "objectTitle"}, title);
-  },
-
-  safePropIterator: function (object, max) {
-    max = (typeof max === "undefined") ? 3 : max;
-    try {
-      return this.propIterator(object, max);
-    } catch (err) {
-      console.error(err);
-    }
-    return [];
-  },
-
-  propIterator: function (object, max) {
-    let isInterestingProp = (t, value) => {
-      // Do not pick objects, it could cause recursion.
-      return (t == "boolean" || t == "number" || (t == "string" && value));
-    };
-
-    // Work around https://bugzilla.mozilla.org/show_bug.cgi?id=945377
-    if (Object.prototype.toString.call(object) === "[object Generator]") {
-      object = Object.getPrototypeOf(object);
-    }
-
-    // Object members with non-empty values are preferred since it gives the
-    // user a better overview of the object.
-    let propsArray = this.getPropsArray(object, max, isInterestingProp);
-
-    if (propsArray.length <= max) {
-      // There are not enough props yet (or at least, not enough props to
-      // be able to know whether we should print "more…" or not).
-      // Let's display also empty members and functions.
-      propsArray = propsArray.concat(this.getPropsArray(object, max, (t, value) => {
-        return !isInterestingProp(t, value);
-      }));
-    }
-
-    if (propsArray.length > max) {
-      propsArray.pop();
-      let objectLink = this.props.objectLink || span;
-
-      propsArray.push(Caption({
-        object: objectLink({
-          object: object
-        }, (Object.keys(object).length - max) + " more…")
-      }));
-    } else if (propsArray.length > 0) {
-      // Remove the last comma.
-      propsArray[propsArray.length - 1] = React.cloneElement(
-        propsArray[propsArray.length - 1], { delim: "" });
-    }
-
-    return propsArray;
-  },
-
-  getPropsArray: function (object, max, filter) {
-    let propsArray = [];
-
-    max = max || 3;
-    if (!object) {
-      return propsArray;
-    }
-
-    // Hardcode tiny mode to avoid recursive handling.
-    let mode = MODE.TINY;
-
-    try {
-      for (let name in object) {
-        if (propsArray.length > max) {
-          return propsArray;
-        }
-
-        let value;
-        try {
-          value = object[name];
-        } catch (exc) {
-          continue;
-        }
-
-        let t = typeof value;
-        if (filter(t, value)) {
-          propsArray.push(PropRep({
-            mode: mode,
-            name: name,
-            object: value,
-            equal: ": ",
-            delim: ", ",
-          }));
-        }
-      }
-    } catch (err) {
-      console.error(err);
-    }
-
-    return propsArray;
-  },
-
-  safeObjectLink: function (config, ...children) {
-    if (this.props.objectLink) {
-      return this.props.objectLink(Object.assign({
-        object: this.props.object
-      }, config), ...children);
-    }
-
-    if (Object.keys(config).length === 0 && children.length === 1) {
-      return children[0];
-    }
-
-    return span(config, ...children);
-  },
-
-  render: wrapRender(function () {
-    let object = this.props.object;
-    let propsArray = this.safePropIterator(object);
-
-    if (this.props.mode === MODE.TINY || !propsArray.length) {
-      return (
-        span({className: "objectBox objectBox-object"},
-          this.getTitle(object)
-        )
-      );
-    }
-
+  if (props.mode === MODE.TINY || !propsArray.length) {
     return (
       span({className: "objectBox objectBox-object"},
-        this.getTitle(object),
-        this.safeObjectLink({
-          className: "objectLeftBrace",
-        }, " { "),
-        ...propsArray,
-        this.safeObjectLink({
-          className: "objectRightBrace",
-        }, " }")
+        getTitle(props, object)
       )
     );
-  }),
-});
+  }
+
+  return (
+    span({className: "objectBox objectBox-object"},
+      getTitle(props, object),
+      safeObjectLink(props, {
+        className: "objectLeftBrace",
+      }, " { "),
+      ...propsArray,
+      safeObjectLink(props, {
+        className: "objectRightBrace",
+      }, " }")
+    )
+  );
+}
+
+function getTitle(props, object) {
+  let title = props.title || object.class || "Object";
+  return safeObjectLink(props, {className: "objectTitle"}, title);
+}
+
+function safePropIterator(props, object, max) {
+  max = (typeof max === "undefined") ? 3 : max;
+  try {
+    return propIterator(props, object, max);
+  } catch (err) {
+    console.error(err);
+  }
+  return [];
+}
+
+function propIterator(props, object, max) {
+  let isInterestingProp = (t, value) => {
+    // Do not pick objects, it could cause recursion.
+    return (t == "boolean" || t == "number" || (t == "string" && value));
+  };
+
+  // Work around https://bugzilla.mozilla.org/show_bug.cgi?id=945377
+  if (Object.prototype.toString.call(object) === "[object Generator]") {
+    object = Object.getPrototypeOf(object);
+  }
+
+  // Object members with non-empty values are preferred since it gives the
+  // user a better overview of the object.
+  let interestingObject = getFilteredObject(object, max, isInterestingProp);
+
+  if (Object.keys(interestingObject).length < max) {
+    // There are not enough props yet (or at least, not enough props to
+    // be able to know whether we should print "more…" or not).
+    // Let's display also empty members and functions.
+    interestingObject = Object.assign({}, interestingObject,
+      getFilteredObject(
+        object,
+        max - Object.keys(interestingObject).length,
+        (t, value) => !isInterestingProp(t, value)
+      )
+    );
+  }
+
+  const truncate = Object.keys(object).length > max;
+  let propsArray = getPropsArray(interestingObject, truncate);
+  if (truncate) {
+    propsArray.push(Caption({
+      object: safeObjectLink(props, {},
+        (Object.keys(object).length - max) + " more…")
+    }));
+  }
+
+  return propsArray;
+}
+
+/**
+ * Get an array of components representing the properties of the object
+ *
+ * @param {Object} object
+ * @param {Boolean} truncate true if the object will be truncated.
+ * @return {Array} Array of PropRep.
+ */
+function getPropsArray(object, truncate) {
+  let propsArray = [];
+
+  if (!object) {
+    return propsArray;
+  }
+
+  // Hardcode tiny mode to avoid recursive handling.
+  let mode = MODE.TINY;
+
+  return Object.keys(object).map((name, i) => PropRep({
+    mode,
+    name,
+    object: object[name],
+    equal: ": ",
+    delim: i !== Object.keys(object).length - 1 || truncate ? ", " : "",
+  }));
+}
+
+/**
+ * Get a copy of the object filtered by a given predicate.
+ *
+ * @param {Object} object.
+ * @param {Number} max The maximum length of keys array.
+ * @param {Function} filter Filter the props you want.
+ * @return {Object} the filtered object.
+ */
+function getFilteredObject(object, max, filter) {
+  let filteredObject = {};
+
+  try {
+    for (let name in object) {
+      if (Object.keys(filteredObject).length >= max) {
+        return filteredObject;
+      }
+
+      let value;
+      try {
+        value = object[name];
+      } catch (exc) {
+        continue;
+      }
+
+      let t = typeof value;
+      if (filter(t, value)) {
+        filteredObject[name] = value;
+      }
+    }
+  } catch (err) {
+    console.error(err);
+  }
+  return filteredObject;
+}
+
 function supportsObject(object, type) {
   return true;
 }
 
 // Exports from this module
 module.exports = {
-  rep: Obj,
-  supportsObject: supportsObject
+  rep: wrapRender(ObjectRep),
+  supportsObject,
 };

--- a/src/reps/prop-rep.js
+++ b/src/reps/prop-rep.js
@@ -1,7 +1,6 @@
 // Dependencies
 const React = require("react");
 const {
-  createFactories,
   maybeEscapePropertyName,
   wrapRender,
 } = require("./rep-utils");
@@ -14,73 +13,70 @@ const { span } = React.DOM;
  * and GripMap (remote JS maps and weakmaps) reps.
  * It's used to render object properties.
  */
-let PropRep = React.createClass({
-  displayName: "PropRep",
+PropRep.propTypes = {
+  // Property name.
+  name: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.object,
+  ]).isRequired,
+  // Equal character rendered between property name and value.
+  equal: React.PropTypes.string,
+  // Delimiter character used to separate individual properties.
+  delim: React.PropTypes.string,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  objectLink: React.PropTypes.func,
+  attachedActorIds: React.PropTypes.array,
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+  // Normally a PropRep will quote a property name that isn't valid
+  // when unquoted; but this flag can be used to suppress the
+  // quoting.
+  suppressQuotes: React.PropTypes.bool,
+};
 
-  propTypes: {
-    // Property name.
-    name: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]).isRequired,
-    // Equal character rendered between property name and value.
-    equal: React.PropTypes.string,
-    // Delimiter character used to separate individual properties.
-    delim: React.PropTypes.string,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    objectLink: React.PropTypes.func,
-    attachedActorIds: React.PropTypes.array,
-    onDOMNodeMouseOver: React.PropTypes.func,
-    onDOMNodeMouseOut: React.PropTypes.func,
-    onInspectIconClick: React.PropTypes.func,
-    // Normally a PropRep will quote a property name that isn't valid
-    // when unquoted; but this flag can be used to suppress the
-    // quoting.
-    suppressQuotes: React.PropTypes.bool,
-  },
+function PropRep(props) {
+  const Grip = require("./grip");
+  const { Rep } = require("./rep");
 
-  render: wrapRender(function () {
-    const Grip = require("./grip");
-    let { Rep } = createFactories(require("./rep"));
-    let {
-      name,
-      mode,
-      equal,
-      delim,
-      suppressQuotes,
-    } = this.props;
+  let {
+    name,
+    mode,
+    equal,
+    delim,
+    suppressQuotes,
+  } = props;
 
-    let key;
-    // The key can be a simple string, for plain objects,
-    // or another object for maps and weakmaps.
-    if (typeof name === "string") {
-      if (!suppressQuotes) {
-        name = maybeEscapePropertyName(name);
-      }
-      key = span({"className": "nodeName"}, name);
-    } else {
-      key = Rep(Object.assign({}, this.props, {
-        object: name,
-        mode: mode || MODE.TINY,
-        defaultRep: Grip,
-      }));
+  let key;
+  // The key can be a simple string, for plain objects,
+  // or another object for maps and weakmaps.
+  if (typeof name === "string") {
+    if (!suppressQuotes) {
+      name = maybeEscapePropertyName(name);
     }
+    key = span({"className": "nodeName"}, name);
+  } else {
+    key = Rep(Object.assign({}, props, {
+      object: name,
+      mode: mode || MODE.TINY,
+      defaultRep: Grip,
+    }));
+  }
 
-    return (
-      span({},
-        key,
-        span({
-          "className": "objectEqual"
-        }, equal),
-        Rep(Object.assign({}, this.props)),
-        span({
-          "className": "objectComma"
-        }, delim)
-      )
-    );
-  })
-});
+  return (
+    span({},
+      key,
+      span({
+        "className": "objectEqual"
+      }, equal),
+      Rep(Object.assign({}, props)),
+      span({
+        "className": "objectComma"
+      }, delim)
+    )
+  );
+}
 
 // Exports from this module
-module.exports = PropRep;
+module.exports = wrapRender(PropRep);

--- a/src/reps/regexp.js
+++ b/src/reps/regexp.js
@@ -4,46 +4,33 @@ const React = require("react");
 // Reps
 const {
   isGrip,
+  safeObjectLink,
   wrapRender,
 } = require("./rep-utils");
-
-// Shortcuts
-const { span } = React.DOM;
 
 /**
  * Renders a grip object with regular expression.
  */
-let RegExp = React.createClass({
-  displayName: "regexp",
+RegExp.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function RegExp(props) {
+  let {object} = props;
 
-  getSource: function (grip) {
-    return grip.displayString;
-  },
+  return (
+    safeObjectLink(props, {
+      className: "objectBox objectBox-regexp regexpSource"
+    }, getSource(object))
+  );
+}
 
-  render: wrapRender(function () {
-    let {object} = this.props;
-    let objectLink = (config, ...children) => {
-      if (this.props.objectLink) {
-        return this.props.objectLink(Object.assign({object}, config), ...children);
-      }
-      return span(config, ...children);
-    };
-
-    return (
-      objectLink({
-        className: "objectBox objectBox-regexp regexpSource"
-      }, this.getSource(object))
-    );
-  }),
-});
+function getSource(grip) {
+  return grip.displayString;
+}
 
 // Registration
-
 function supportsObject(object, type) {
   if (!isGrip(object)) {
     return false;
@@ -54,6 +41,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: RegExp,
-  supportsObject: supportsObject
+  rep: wrapRender(RegExp),
+  supportsObject,
 };

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -255,10 +255,11 @@ function splitURLTrue(url) {
  * fallback rep if the render fails.
  */
 function wrapRender(renderMethod) {
-  return function () {
+  const wrappedFunction = function (props) {
     try {
-      return renderMethod.call(this);
+      return renderMethod.call(this, props);
     } catch (e) {
+      console.error(e);
       return React.DOM.span(
         {
           className: "objectBox objectBox-failure",
@@ -269,6 +270,8 @@ function wrapRender(renderMethod) {
         "Invalid object");
     }
   };
+  wrappedFunction.propTypes = renderMethod.propTypes;
+  return wrappedFunction;
 }
 
 /**
@@ -373,6 +376,25 @@ function getGripPreviewItems(grip) {
   return [];
 }
 
+function safeObjectLink(props, config, ...children) {
+  const {
+    objectLink,
+    object,
+  } = props;
+
+  if (objectLink) {
+    return objectLink(Object.assign({
+      object
+    }, config), ...children);
+  }
+
+  if (Object.keys(config).length === 0 && children.length === 1) {
+    return children[0];
+  }
+
+  return React.DOM.span(config, ...children);
+}
+
 module.exports = {
   createFactories,
   isGrip,
@@ -388,4 +410,5 @@ module.exports = {
   getURLDisplayString,
   getSelectableInInspectorGrips,
   maybeEscapePropertyName,
+  safeObjectLink,
 };

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -376,6 +376,17 @@ function getGripPreviewItems(grip) {
   return [];
 }
 
+/**
+ * Returns a new element wrapped with a component, props.objectLink if it exists,
+ * or a soan if there are multiple childs, or directly the child if only one is passed.
+ *
+ * @param {Object} props A Rep "props" object that may contain `objectLink`
+ *                 and `object` properties.
+ * @param {Object} config Object to pass as props to the `objectLink` component.
+ * @param {...Element} children Elements to be wrapped with the `objectLink` component.
+ * @return {Element} Element, wrapped or not depending if `objectLink`
+ *                   was supplied in props.
+ */
 function safeObjectLink(props, config, ...children) {
   const {
     objectLink,
@@ -388,7 +399,7 @@ function safeObjectLink(props, config, ...children) {
     }, config), ...children);
   }
 
-  if (Object.keys(config).length === 0 && children.length === 1) {
+  if ((!config || Object.keys(config).length === 0) && children.length === 1) {
     return children[0];
   }
 

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -378,13 +378,13 @@ function getGripPreviewItems(grip) {
 
 /**
  * Returns a new element wrapped with a component, props.objectLink if it exists,
- * or a soan if there are multiple childs, or directly the child if only one is passed.
+ * or a span if there are multiple childs, or directly the child if only one is passed.
  *
  * @param {Object} props A Rep "props" object that may contain `objectLink`
  *                 and `object` properties.
  * @param {Object} config Object to pass as props to the `objectLink` component.
  * @param {...Element} children Elements to be wrapped with the `objectLink` component.
- * @return {Element} Element, wrapped or not depending if `objectLink`
+ * @return {Element} Element, wrapped or not, depending if `objectLink`
  *                   was supplied in props.
  */
 function safeObjectLink(props, config, ...children) {

--- a/src/reps/rep.js
+++ b/src/reps/rep.js
@@ -1,7 +1,4 @@
-const React = require("react");
-
 const { isGrip } = require("./rep-utils");
-const { MODE } = require("./constants");
 
 // Load all existing rep templates
 const Undefined = require("./undefined");
@@ -74,21 +71,14 @@ let reps = [
  * to the current value type. The value must be passed is as 'object'
  * property.
  */
-const Rep = React.createClass({
-  displayName: "Rep",
-
-  propTypes: {
-    object: React.PropTypes.any,
-    defaultRep: React.PropTypes.object,
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-  },
-
-  render: function () {
-    let rep = getRep(this.props.object, this.props.defaultRep);
-    return rep(this.props);
-  },
-});
+const Rep = function (props) {
+  let {
+    object,
+    defaultRep,
+  } = props;
+  let rep = getRep(object, defaultRep);
+  return rep(props);
+};
 
 // Helpers
 
@@ -122,14 +112,14 @@ function getRep(object, defaultRep = Obj) {
       // but a number), which would allow to priorities templates and
       // support better extensibility.
       if (rep.supportsObject(object, type)) {
-        return React.createFactory(rep.rep);
+        return rep.rep;
       }
     } catch (err) {
       console.error(err);
     }
   }
 
-  return React.createFactory(defaultRep.rep);
+  return defaultRep.rep;
 }
 
 module.exports = {
@@ -164,5 +154,7 @@ module.exports = {
     TextNode,
     Undefined,
     Window,
-  }
+  },
+  // Exporting for tests
+  getRep,
 };

--- a/src/reps/string.js
+++ b/src/reps/string.js
@@ -14,46 +14,39 @@ const { span } = React.DOM;
 /**
  * Renders a string. String value is enclosed within quotes.
  */
-const StringRep = React.createClass({
-  displayName: "StringRep",
+StringRep.propTypes = {
+  useQuotes: React.PropTypes.bool,
+  style: React.PropTypes.object,
+  object: React.PropTypes.string.isRequired,
+  member: React.PropTypes.any,
+  cropLimit: React.PropTypes.number,
+};
 
-  propTypes: {
-    useQuotes: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    object: React.PropTypes.string.isRequired,
-    member: React.PropTypes.any,
-    cropLimit: React.PropTypes.number,
-  },
+function StringRep(props) {
+  let {
+    object: text,
+    member,
+    style,
+    useQuotes = true,
+  } = props;
 
-  getDefaultProps: function () {
-    return {
-      useQuotes: true,
-    };
-  },
+  let config = {className: "objectBox objectBox-string"};
+  if (style) {
+    config.style = style;
+  }
 
-  render: wrapRender(function () {
-    let text = this.props.object;
-    let member = this.props.member;
-    let style = this.props.style;
+  if (useQuotes) {
+    text = escapeString(text);
+  } else {
+    text = sanitizeString(text);
+  }
 
-    let config = {className: "objectBox objectBox-string"};
-    if (style) {
-      config.style = style;
-    }
+  if ((!member || !member.open) && props.cropLimit) {
+    text = rawCropString(text, props.cropLimit);
+  }
 
-    if (this.props.useQuotes) {
-      text = escapeString(text);
-    } else {
-      text = sanitizeString(text);
-    }
-
-    if ((!member || !member.open) && this.props.cropLimit) {
-      text = rawCropString(text, this.props.cropLimit);
-    }
-
-    return span(config, text);
-  }),
-});
+  return span(config, text);
+}
 
 function supportsObject(object, type) {
   return (type == "string");
@@ -62,6 +55,6 @@ function supportsObject(object, type) {
 // Exports from this module
 
 module.exports = {
-  rep: StringRep,
-  supportsObject: supportsObject,
+  rep: wrapRender(StringRep),
+  supportsObject,
 };

--- a/src/reps/string.js
+++ b/src/reps/string.js
@@ -24,6 +24,7 @@ StringRep.propTypes = {
 
 function StringRep(props) {
   let {
+    cropLimit,
     object: text,
     member,
     style,
@@ -41,8 +42,8 @@ function StringRep(props) {
     text = sanitizeString(text);
   }
 
-  if ((!member || !member.open) && props.cropLimit) {
-    text = rawCropString(text, props.cropLimit);
+  if ((!member || !member.open) && cropLimit) {
+    text = rawCropString(text, cropLimit);
   }
 
   return span(config, text);

--- a/src/reps/stylesheet.js
+++ b/src/reps/stylesheet.js
@@ -5,57 +5,44 @@ const React = require("react");
 const {
   isGrip,
   getURLDisplayString,
+  safeObjectLink,
   wrapRender
 } = require("./rep-utils");
 
 // Shortcuts
-const DOM = React.DOM;
+const {span} = React.DOM;
 
 /**
  * Renders a grip representing CSSStyleSheet
  */
-let StyleSheet = React.createClass({
-  displayName: "object",
+StyleSheet.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function StyleSheet(props) {
+  let grip = props.object;
 
-  getTitle: function (grip) {
-    let title = "StyleSheet ";
-    if (this.props.objectLink) {
-      return DOM.span({className: "objectBox"},
-        this.props.objectLink({
-          object: grip
-        }, title)
-      );
-    }
-    return title;
-  },
+  return (
+    span({className: "objectBox objectBox-object"},
+      getTitle(props, grip),
+      span({className: "objectPropValue"}, getLocation(grip))
+    )
+  );
+}
 
-  getLocation: function (grip) {
-    // Embedded stylesheets don't have URL and so, no preview.
-    let url = grip.preview ? grip.preview.url : "";
-    return url ? getURLDisplayString(url) : "";
-  },
+function getTitle(props, grip) {
+  let title = "StyleSheet ";
+  return safeObjectLink(props, {className: "objectBox"}, title);
+}
 
-  render: wrapRender(function () {
-    let grip = this.props.object;
-
-    return (
-      DOM.span({className: "objectBox objectBox-object"},
-        this.getTitle(grip),
-        DOM.span({className: "objectPropValue"},
-          this.getLocation(grip)
-        )
-      )
-    );
-  }),
-});
+function getLocation(grip) {
+  // Embedded stylesheets don't have URL and so, no preview.
+  let url = grip.preview ? grip.preview.url : "";
+  return url ? getURLDisplayString(url) : "";
+}
 
 // Registration
-
 function supportsObject(object, type) {
   if (!isGrip(object)) {
     return false;
@@ -67,6 +54,6 @@ function supportsObject(object, type) {
 // Exports from this module
 
 module.exports = {
-  rep: StyleSheet,
-  supportsObject: supportsObject
+  rep: wrapRender(StyleSheet),
+  supportsObject,
 };

--- a/src/reps/symbol.js
+++ b/src/reps/symbol.js
@@ -9,24 +9,20 @@ const { span } = React.DOM;
 /**
  * Renders a symbol.
  */
-const SymbolRep = React.createClass({
-  displayName: "SymbolRep",
+SymbolRep.propTypes = {
+  object: React.PropTypes.object.isRequired
+};
 
-  propTypes: {
-    object: React.PropTypes.object.isRequired
-  },
+function SymbolRep(props) {
+  let {object} = props;
+  let {name} = object;
 
-  render: wrapRender(function () {
-    let {object} = this.props;
-    let {name} = object;
-
-    return (
-      span({className: "objectBox objectBox-symbol"},
-        `Symbol(${name || ""})`
-      )
-    );
-  }),
-});
+  return (
+    span({className: "objectBox objectBox-symbol"},
+      `Symbol(${name || ""})`
+    )
+  );
+}
 
 function supportsObject(object, type) {
   return (type == "symbol");
@@ -34,6 +30,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: SymbolRep,
-  supportsObject: supportsObject,
+  rep: wrapRender(SymbolRep),
+  supportsObject,
 };

--- a/src/reps/undefined.js
+++ b/src/reps/undefined.js
@@ -9,17 +9,13 @@ const { span } = React.DOM;
 /**
  * Renders undefined value
  */
-const Undefined = React.createClass({
-  displayName: "UndefinedRep",
-
-  render: wrapRender(function () {
-    return (
-      span({className: "objectBox objectBox-undefined"},
-        "undefined"
-      )
-    );
-  }),
-});
+const Undefined = function () {
+  return (
+    span({className: "objectBox objectBox-undefined"},
+      "undefined"
+    )
+  );
+};
 
 function supportsObject(object, type) {
   if (object && object.type && object.type == "undefined") {
@@ -32,6 +28,6 @@ function supportsObject(object, type) {
 // Exports from this module
 
 module.exports = {
-  rep: Undefined,
-  supportsObject: supportsObject
+  rep: wrapRender(Undefined),
+  supportsObject,
 };

--- a/src/reps/window.js
+++ b/src/reps/window.js
@@ -5,71 +5,60 @@ const React = require("react");
 const {
   isGrip,
   getURLDisplayString,
+  safeObjectLink,
   wrapRender
 } = require("./rep-utils");
 
 const { MODE } = require("./constants");
 
 // Shortcuts
-const DOM = React.DOM;
+const {span} = React.DOM;
 
 /**
  * Renders a grip representing a window.
  */
-let Window = React.createClass({
-  displayName: "Window",
+WindowRep.propTypes = {
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  object: React.PropTypes.object.isRequired,
+  objectLink: React.PropTypes.func,
+};
 
-  propTypes: {
-    // @TODO Change this to Object.values once it's supported in Node's version of V8
-    mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
-    object: React.PropTypes.object.isRequired,
-    objectLink: React.PropTypes.func,
-  },
+function WindowRep(props) {
+  let {
+    mode,
+    object,
+  } = props;
 
-  getTitle: function (object) {
-    let title = object.displayClass || object.class || "Window";
-    if (this.props.objectLink) {
-      return DOM.span({className: "objectBox"},
-        this.props.objectLink({
-          object
-        }, title)
-      );
-    }
-    return title;
-  },
-
-  getLocation: function (object) {
-    return getURLDisplayString(object.preview.url);
-  },
-
-  render: wrapRender(function () {
-    let {
-      mode,
-      object,
-    } = this.props;
-
-    if (mode === MODE.TINY) {
-      return (
-        DOM.span({className: "objectBox objectBox-Window"},
-          this.getTitle(object)
-        )
-      );
-    }
-
+  if (mode === MODE.TINY) {
     return (
-      DOM.span({className: "objectBox objectBox-Window"},
-        this.getTitle(object),
-        " ",
-        DOM.span({className: "objectPropValue"},
-          this.getLocation(object)
-        )
+      span({className: "objectBox objectBox-Window"},
+        getTitle(props, object)
       )
     );
-  }),
-});
+  }
+
+  return (
+    span({className: "objectBox objectBox-Window"},
+      getTitle(props, object),
+      " ",
+      span({className: "objectPropValue"},
+        getLocation(object)
+      )
+    )
+  );
+}
+
+function getTitle(props, object) {
+  let title = object.displayClass || object.class || "Window";
+  return safeObjectLink(props, {className: "objectBox"}, title);
+}
+
+function getLocation(object) {
+  return getURLDisplayString(object.preview.url);
+}
 
 // Registration
-
 function supportsObject(object, type) {
   if (!isGrip(object)) {
     return false;
@@ -80,6 +69,6 @@ function supportsObject(object, type) {
 
 // Exports from this module
 module.exports = {
-  rep: Window,
-  supportsObject: supportsObject
+  rep: wrapRender(WindowRep),
+  supportsObject,
 };

--- a/src/test/mochitest/test_reps_array.html
+++ b/src/test/mochitest/test_reps_array.html
@@ -20,7 +20,11 @@ Test ArrayRep rep
 /* import-globals-from head.js */
 
 window.onload = Task.async(function* () {
-  const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    MODE,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, ArrayRep } = REPS;
 
   let componentUnderTest = ArrayRep;
@@ -52,9 +56,7 @@ window.onload = Task.async(function* () {
   function testBasic() {
     // Test that correct rep is chosen
     const stub = [];
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ArrayRep.rep,
-       `Rep correctly selects ${ArrayRep.rep.displayName}`);
+    is(getRep(stub), ArrayRep.rep, "Rep correctly selects Array Rep");
 
 
     // Test rendering

--- a/src/test/mochitest/test_reps_attribute.html
+++ b/src/test/mochitest/test_reps_attribute.html
@@ -17,7 +17,10 @@ Test Attribute rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Attribute } = REPS;
 
   try {
@@ -31,8 +34,7 @@ window.onload = Task.async(function* () {
 
   function testBasic() {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: getStub() });
-    is(renderedRep.type, Attribute.rep, `Rep correctly selects ${Attribute.rep.displayName}`);
+    is(getRep(getStub()), Attribute.rep, "Rep correctly selects Attribute Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(Attribute.rep, { object: getStub() });

--- a/src/test/mochitest/test_reps_comment-node.html
+++ b/src/test/mochitest/test_reps_comment-node.html
@@ -20,7 +20,11 @@ Test comment-node rep
 
 window.onload = Task.async(function* () {
   try {
-    const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      MODE,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, CommentNode } = REPS;
 
     let gripStub = {
@@ -40,9 +44,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, CommentNode.rep,
-      `Rep correctly selects ${CommentNode.rep.displayName}`);
+    is(getRep(gripStub), CommentNode.rep, "Rep correctly selects CommentNode Rep");
 
     // Test rendering.
     const renderedComponent = renderComponent(CommentNode.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_date-time.html
+++ b/src/test/mochitest/test_reps_date-time.html
@@ -17,7 +17,10 @@ Test DateTime rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, DateTime } = REPS;
 
   try {
@@ -45,12 +48,11 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, DateTime.rep, `Rep correctly selects ${DateTime.rep.displayName}`);
+    is(getRep(gripStub), DateTime.rep, "Rep correctly selects DateTime Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(DateTime.rep, { object: gripStub });
-    is(renderedComponent.textContent, "2016-03-30T21:17:24.859Z", "DateTime rep has expected text content for valid date");
+    is(renderedComponent.textContent, "Date 2016-03-30T21:17:24.859Z", "DateTime rep has expected text content for valid date");
   }
 
   function testInvalid() {

--- a/src/test/mochitest/test_reps_document.html
+++ b/src/test/mochitest/test_reps_document.html
@@ -17,7 +17,10 @@ Test Document rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Document } = REPS;
 
   try {
@@ -31,12 +34,11 @@ window.onload = Task.async(function* () {
 
   function testBasic() {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: getStub() });
-    is(renderedRep.type, Document.rep, `Rep correctly selects ${Document.rep.displayName}`);
+    is(getRep(getStub()), Document.rep, "Rep correctly selects Document Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(Document.rep, { object: getStub() });
-    is(renderedComponent.textContent, "https://www.mozilla.org/en-US/firefox/new/",
+    is(renderedComponent.textContent, "HTMLDocument https://www.mozilla.org/en-US/firefox/new/",
       "Document rep has expected text content");
   }
 

--- a/src/test/mochitest/test_reps_element-node.html
+++ b/src/test/mochitest/test_reps_element-node.html
@@ -22,6 +22,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, ElementNode } = REPS;
@@ -48,9 +49,8 @@ window.onload = Task.async(function* () {
 
   function testBodyNode() {
     const stub = getGripStub("testBodyNode");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
-      `Rep correctly selects ${ElementNode.rep.displayName} for body node`);
+    is(getRep(stub), ElementNode.rep,
+      "Rep correctly selects ElementNode Rep for body node");
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
     is(renderedComponent.textContent, `<body id="body-id" class="body-class">`,
@@ -64,9 +64,8 @@ window.onload = Task.async(function* () {
 
   function testDocumentElement() {
     const stub = getGripStub("testDocumentElement");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
-      `Rep correctly selects ${ElementNode.rep.displayName} for document element node`);
+    is(getRep(stub), ElementNode.rep,
+      "Rep correctly selects ElementNode Rep for document element node");
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
     is(renderedComponent.textContent, `<html dir="ltr" lang="en-US">`,
@@ -80,9 +79,8 @@ window.onload = Task.async(function* () {
 
   function testNode() {
     const stub = getGripStub("testNode");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
-      `Rep correctly selects ${ElementNode.rep.displayName} for element node`);
+    is(getRep(stub), ElementNode.rep,
+      "Rep correctly selects ElementNode Rep for element node");
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
     is(renderedComponent.textContent,
@@ -99,9 +97,8 @@ window.onload = Task.async(function* () {
 
   function testNodeWithLeadingAndTrailingSpacesClassName() {
     const stub = getGripStub("testNodeWithLeadingAndTrailingSpacesClassName");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
-      `Rep correctly selects ${ElementNode.rep.displayName} for element node`);
+    is(getRep(stub), ElementNode.rep,
+      "Rep correctly selects ElementNode Rep for element node");
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
     is(renderedComponent.textContent,
@@ -119,8 +116,7 @@ window.onload = Task.async(function* () {
   function testNodeWithoutAttributes() {
     const stub = getGripStub("testNodeWithoutAttributes");
 
-    const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
-    is(renderedComponent.textContent, "<p>",
+    is(getRep(stub), ElementNode.rep,
       "Element node rep has expected text content for element node without attributes");
 
     const tinyRenderedComponent = renderComponent(
@@ -147,8 +143,7 @@ window.onload = Task.async(function* () {
   function testSvgNode() {
     const stub = getGripStub("testSvgNode");
 
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
+    is(getRep(stub), ElementNode.rep,
       `Rep correctly selects ${ElementNode.rep.displayName} for SVG element node`);
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
@@ -165,8 +160,7 @@ window.onload = Task.async(function* () {
   function testSvgNodeInXHTML() {
     const stub = getGripStub("testSvgNodeInXHTML");
 
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, ElementNode.rep,
+    is(getRep(stub), ElementNode.rep,
       `Rep correctly selects ${ElementNode.rep.displayName} for XHTML SVG element node`);
 
     const renderedComponent = renderComponent(ElementNode.rep, { object: stub });
@@ -182,7 +176,6 @@ window.onload = Task.async(function* () {
 
   function testOnMouseOver() {
     const stub = getGripStub("testNode");
-  debugger;
     const grips = getSelectableInInspectorGrips(stub);
     is(grips.length, 1, "the stub has one node grip");
 

--- a/src/test/mochitest/test_reps_error.html
+++ b/src/test/mochitest/test_reps_error.html
@@ -19,7 +19,11 @@ Test Error rep
 "use strict";
 
 window.onload = Task.async(function* () {
-  const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    MODE,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, ErrorRep } = REPS;
 
   try {
@@ -47,9 +51,7 @@ window.onload = Task.async(function* () {
   function testSimpleError() {
     // Test object = `new Error("Error message")`
     const stub = getGripStub("testSimpleError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for Error object`);
+    is(getRep(stub), ErrorRep.rep, "Rep correctly selects Error Rep for Error object");
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -77,9 +79,8 @@ window.onload = Task.async(function* () {
      *   errorFoo();`
      */
     const stub = getGripStub("testMultilineStackError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for Error object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for Error object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -99,9 +100,8 @@ window.onload = Task.async(function* () {
 
   function testErrorWithoutStacktrace() {
     const stub = getGripStub("testErrorWithoutStacktrace");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for Error object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for Error object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -118,9 +118,8 @@ window.onload = Task.async(function* () {
   function testEvalError() {
     // Test object = `new EvalError("EvalError message")`
     const stub = getGripStub("testEvalError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for EvalError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for EvalError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -139,9 +138,8 @@ window.onload = Task.async(function* () {
   function testInternalError() {
     // Test object = `new InternalError("InternalError message")`
     const stub = getGripStub("testInternalError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for InternalError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for InternalError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -160,9 +158,8 @@ window.onload = Task.async(function* () {
   function testRangeError() {
     // Test object = `new RangeError("RangeError message")`
     const stub = getGripStub("testRangeError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for RangeError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for RangeError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -181,9 +178,8 @@ window.onload = Task.async(function* () {
   function testReferenceError() {
     // Test object = `new ReferenceError("ReferenceError message"`
     const stub = getGripStub("testReferenceError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for ReferenceError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for ReferenceError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -202,9 +198,8 @@ window.onload = Task.async(function* () {
   function testSyntaxError() {
     // Test object = `new SyntaxError("SyntaxError message"`
     const stub = getGripStub("testSyntaxError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for SyntaxError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for SyntaxError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -223,9 +218,8 @@ window.onload = Task.async(function* () {
   function testTypeError() {
     // Test object = `new TypeError("TypeError message"`
     const stub = getGripStub("testTypeError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for TypeError`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for TypeError`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,
@@ -244,9 +238,8 @@ window.onload = Task.async(function* () {
   function testURIError() {
     // Test object = `new URIError("URIError message")`
     const stub = getGripStub("testURIError");
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, ErrorRep.rep,
-      `Rep correctly selects ${ErrorRep.rep.displayName} for URIError object`);
+    is(getRep(stub), ErrorRep.rep,
+      `Rep correctly selects Error Rep for URIError object`);
 
     const renderedComponent = renderComponent(ErrorRep.rep, {object: stub});
     is(renderedComponent.textContent,

--- a/src/test/mochitest/test_reps_event.html
+++ b/src/test/mochitest/test_reps_event.html
@@ -20,14 +20,14 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Event } = REPS;
 
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testEvent") });
-    is(renderedRep.type, Event.rep, `Rep correctly selects ${Event.rep.displayName}`);
+    is(getRep(getGripStub("testEvent")), Event.rep, "Rep correctly selects Event Rep");
 
     yield testEvent();
     yield testMouseEvent();

--- a/src/test/mochitest/test_reps_failure.html
+++ b/src/test/mochitest/test_reps_failure.html
@@ -18,7 +18,10 @@ Test fallback for rep rendering when a rep fails to render.
 <script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, ArrayRep, RegExp } = REPS;
 
     // Force the RegExp rep to crash by creating RegExp grip that throws when accessing
@@ -37,8 +40,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, RegExp.rep, `Rep correctly selects ${RegExp.rep.displayName}`);
+    is(getRep(gripStub), RegExp.rep, "Rep correctly selects RegExp Rep");
 
     // Test fallback message is displayed when rendering bad rep directly.
     let renderedComponent = renderComponent(RegExp.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_function.html
+++ b/src/test/mochitest/test_reps_function.html
@@ -17,7 +17,11 @@ Test Func rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    MODE,
+    getRep,
+   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Func } = REPS;
 
   const componentUnderTest = Func;
@@ -25,8 +29,7 @@ window.onload = Task.async(function* () {
   try {
     // Test that correct rep is chosen
     const gripStub = getGripStub("testNamed");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Func.rep, `Rep correctly selects ${Func.rep.displayName}`);
+    is(getRep(gripStub), Func.rep, "Rep correctly selects Func Rep");
 
     yield testNamed();
     yield testVarNamed();

--- a/src/test/mochitest/test_reps_grip-array.html
+++ b/src/test/mochitest/test_reps_grip-array.html
@@ -20,6 +20,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, GripArray } = REPS;
@@ -60,8 +61,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub("testBasic");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, GripArray.rep, `Rep correctly selects ${GripArray.rep.displayName}`);
+    is(getRep(gripStub), GripArray.rep, "Rep correctly selects GripArray Rep");
 
     // Test rendering
     const defaultOutput = `Array []`;

--- a/src/test/mochitest/test_reps_grip-map.html
+++ b/src/test/mochitest/test_reps_grip-map.html
@@ -22,6 +22,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, GripMap } = REPS;
@@ -55,8 +56,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub("testEmptyMap");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, GripMap.rep, `Rep correctly selects ${GripMap.rep.displayName}`);
+    is(getRep(gripStub), GripMap.rep, "Rep correctly selects GripMap Rep");
 
     // Test rendering
     const defaultOutput = `Map {  }`;
@@ -118,8 +118,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub("testWeakMap");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, GripMap.rep, `Rep correctly selects ${GripMap.rep.displayName}`);
+    is(getRep(gripStub), GripMap.rep, "Rep correctly selects GripMap Rep");
 
     // Test rendering
     const defaultOutput = `WeakMap { Object: "value-a" }`;

--- a/src/test/mochitest/test_reps_grip.html
+++ b/src/test/mochitest/test_reps_grip.html
@@ -20,6 +20,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Grip } = REPS;
@@ -66,8 +67,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub("testBasic");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `Object {  }`;
@@ -100,8 +100,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `Boolean { true }`;
@@ -134,8 +133,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `Number { 42 }`;
@@ -168,8 +166,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `String { "foo" }`;
@@ -202,8 +199,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `Proxy { <target>: Object, <handler>: [3] }`;
@@ -236,8 +232,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `ArrayBuffer { byteLength: 10 }`;
@@ -270,8 +265,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `SharedArrayBuffer { byteLength: 5 }`;
@@ -304,8 +298,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub(testName);
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput =
@@ -412,8 +405,7 @@ window.onload = Task.async(function* () {
 
     // Test that correct rep is chosen
     const gripStub = getGripStub("testNonEnumerableProps");
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Grip.rep, `Rep correctly selects ${Grip.rep.displayName}`);
+    is(getRep(gripStub), Grip.rep, "Rep correctly selects Grip Rep");
 
     // Test rendering
     const defaultOutput = `Object {  }`;

--- a/src/test/mochitest/test_reps_infinity.html
+++ b/src/test/mochitest/test_reps_infinity.html
@@ -19,7 +19,10 @@ Test Infinity rep
 "use strict";
 
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, InfinityRep } = REPS;
 
   try {
@@ -33,9 +36,7 @@ window.onload = Task.async(function* () {
 
   function testInfinity() {
     const stub = getGripStub("testInfinity");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, InfinityRep.rep,
-      `Rep correctly selects ${InfinityRep.rep.displayName} for Infinity value`);
+    is(getRep(stub), InfinityRep.rep, "Rep correctly selects Infinity Rep");
 
     const renderedComponent = renderComponent(InfinityRep.rep, { object: stub });
     is(renderedComponent.textContent, "Infinity",
@@ -44,9 +45,7 @@ window.onload = Task.async(function* () {
 
   function testNegativeInfinity() {
     const stub = getGripStub("testNegativeInfinity");
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, InfinityRep.rep,
-      `Rep correctly selects ${InfinityRep.rep.displayName} for negative Infinity value`);
+    is(getRep(stub), InfinityRep.rep, "Rep correctly selects Infinity Rep");
 
     const renderedComponent = renderComponent(InfinityRep.rep, { object: stub });
     is(renderedComponent.textContent, "-Infinity",

--- a/src/test/mochitest/test_reps_long-string.html
+++ b/src/test/mochitest/test_reps_long-string.html
@@ -17,14 +17,16 @@ Test LongString rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, LongStringRep } = REPS;
 
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testMultiline") });
-    is(renderedRep.type, LongStringRep.rep,
-      `Rep correctly selects ${LongStringRep.rep.displayName}`);
+    is(getRep(getGripStub("testMultiline")), LongStringRep.rep,
+      "Rep correctly selects LongString Rep");
 
     // Test rendering
     yield testMultiline();

--- a/src/test/mochitest/test_reps_nan.html
+++ b/src/test/mochitest/test_reps_nan.html
@@ -19,7 +19,10 @@ Test NaN rep
 "use strict";
 
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, NaNRep } = REPS;
 
   try {
@@ -34,9 +37,8 @@ window.onload = Task.async(function* () {
     const stub = {
       type: "NaN"
     };
-    const renderedRep = shallowRenderComponent(Rep, {object: stub});
-    is(renderedRep.type, NaNRep.rep,
-      `Rep correctly selects ${NaNRep.rep.displayName} for NaN value`);
+    is(getRep(stub), NaNRep.rep, "Rep correctly selects NaN Rep");
+
 
     const renderedComponent = renderComponent(NaNRep.rep, {object: stub});
     is(renderedComponent.textContent, "NaN", "NaN rep has expected text content");

--- a/src/test/mochitest/test_reps_null.html
+++ b/src/test/mochitest/test_reps_null.html
@@ -18,7 +18,10 @@ Test Null rep
 <script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, Null } = REPS;
 
     let gripStub = {
@@ -26,8 +29,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Null.rep, `Rep correctly selects ${Null.rep.displayName}`);
+    is(getRep(gripStub), Null.rep, "Rep correctly selects Null Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(Null.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_number.html
+++ b/src/test/mochitest/test_reps_number.html
@@ -17,7 +17,10 @@ Test Number rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Number } = REPS;
 
   try {
@@ -33,16 +36,14 @@ window.onload = Task.async(function* () {
 
 
   function testInt() {
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testInt") });
-    is(renderedRep.type, Number.rep, `Rep correctly selects ${Number.rep.displayName} for integer value`);
+    is(getRep(getGripStub("testInt")), Number.rep, "Rep correctly selects Number Rep");
 
     const renderedComponent = renderComponent(Number.rep, { object: getGripStub("testInt") });
     is(renderedComponent.textContent, "5", "Number rep has expected text content for integer");
   }
 
   function testBoolean() {
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testTrue") });
-    is(renderedRep.type, Number.rep, `Rep correctly selects ${Number.rep.displayName} for boolean value`);
+    is(getRep(getGripStub("testTrue")), Number.rep, "Rep correctly selects Number Rep for boolean value");
 
     let renderedComponent = renderComponent(Number.rep, { object: getGripStub("testTrue") });
     is(renderedComponent.textContent, "true", "Number rep has expected text content for boolean true");
@@ -52,8 +53,7 @@ window.onload = Task.async(function* () {
   }
 
   function testNegativeZero() {
-    const renderedRep = shallowRenderComponent(Rep, { object: getGripStub("testNegZeroGrip") });
-    is(renderedRep.type, Number.rep, `Rep correctly selects ${Number.rep.displayName} for negative zero value`);
+    is(getRep(getGripStub("testNegZeroGrip")), Number.rep, "Rep correctly selects Number Rep for negative zero value");
 
     let renderedComponent = renderComponent(Number.rep, { object: getGripStub("testNegZeroGrip") });
     is(renderedComponent.textContent, "-0", "Number rep has expected text content for negative zero grip");

--- a/src/test/mochitest/test_reps_object-with-text.html
+++ b/src/test/mochitest/test_reps_object-with-text.html
@@ -18,7 +18,10 @@ Test ObjectWithText rep
 <script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, ObjectWithText } = REPS;
 
     let gripStub = {
@@ -36,8 +39,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, ObjectWithText.rep, `Rep correctly selects ${ObjectWithText.rep.displayName}`);
+    is(getRep(gripStub), ObjectWithText.rep, "Rep correctly selects ObjectWithText Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(ObjectWithText.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_object-with-url.html
+++ b/src/test/mochitest/test_reps_object-with-url.html
@@ -21,7 +21,10 @@ window.onload = Task.async(function* () {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");
     let React = browserRequire("devtools/client/shared/vendor/react");
 
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, ObjectWithURL } = REPS;
 
     let gripStub = {
@@ -39,8 +42,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, ObjectWithURL.rep, `Rep correctly selects ${ObjectWithURL.rep.displayName}`);
+    is(getRep(gripStub), ObjectWithURL.rep, "Rep correctly selects ObjectWithURL Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(ObjectWithURL.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_object.html
+++ b/src/test/mochitest/test_reps_object.html
@@ -17,7 +17,11 @@ Test Obj rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    MODE,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, Obj } = REPS;
 
   const componentUnderTest = Obj;
@@ -54,8 +58,7 @@ window.onload = Task.async(function* () {
     const stub = {};
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, Obj.rep, `Rep correctly selects ${Obj.rep.displayName}`);
+    is(getRep(stub), Obj.rep, "Rep correctly selects Obj Rep");
 
     // Test rendering
     const defaultOutput = `Object`;

--- a/src/test/mochitest/test_reps_promise.html
+++ b/src/test/mochitest/test_reps_promise.html
@@ -22,6 +22,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, PromiseRep } = REPS;
@@ -51,9 +52,8 @@ window.onload = Task.async(function* () {
     const stub = getGripStub("testPending");
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    is(renderedRep.type, PromiseRep.rep,
-      `Rep correctly selects ${PromiseRep.rep.displayName} for pending Promise`);
+    is(getRep(stub), PromiseRep.rep,
+      "Rep correctly selects PromiseRep Rep for pending Promise");
 
     // Test rendering
     const defaultOutput = `Promise { <state>: "pending" }`;
@@ -84,10 +84,8 @@ window.onload = Task.async(function* () {
     const stub = getGripStub("testFulfilledWithNumber");
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    const {displayName} = PromiseRep.rep;
-    is(renderedRep.type, PromiseRep.rep,
-      `Rep correctly selects ${displayName} for Promise fulfilled with a number`);
+    is(getRep(stub), PromiseRep.rep,
+      "Rep correctly selects PromiseRep Rep for Promise fulfilled with a number");
 
     // Test rendering
     const defaultOutput = `Promise { <state>: "fulfilled", <value>: 42 }`;
@@ -118,10 +116,8 @@ window.onload = Task.async(function* () {
     const stub = getGripStub("testFulfilledWithString");
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    const {displayName} = PromiseRep.rep;
-    is(renderedRep.type, PromiseRep.rep,
-      `Rep correctly selects ${displayName} for Promise fulfilled with a string`);
+    is(getRep(stub), PromiseRep.rep,
+      "Rep correctly selects PromiseRep Rep for Promise fulfilled with a string");
 
     // Test rendering
     const defaultOutput = `Promise { <state>: "fulfilled", <value>: "foo" }`;
@@ -153,10 +149,8 @@ window.onload = Task.async(function* () {
     const stub = getGripStub("testFulfilledWithObject");
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    const {displayName} = PromiseRep.rep;
-    is(renderedRep.type, PromiseRep.rep,
-      `Rep correctly selects ${displayName} for Promise fulfilled with an object`);
+    is(getRep(stub), PromiseRep.rep,
+      "Rep correctly selects PromiseRep Rep for Promise fulfilled with an object");
 
     // Test rendering
     const defaultOutput = `Promise { <state>: "fulfilled", <value>: Object }`;
@@ -188,10 +182,8 @@ window.onload = Task.async(function* () {
     const stub = getGripStub("testFulfilledWithArray");
 
     // Test that correct rep is chosen.
-    const renderedRep = shallowRenderComponent(Rep, { object: stub });
-    const {displayName} = PromiseRep.rep;
-    is(renderedRep.type, PromiseRep.rep,
-      `Rep correctly selects ${displayName} for Promise fulfilled with an array`);
+    is(getRep(stub), PromiseRep.rep,
+      "Rep correctly selects PromiseRep Rep for Promise fulfilled with an array");
 
     // Test rendering
     const defaultOutput = `Promise { <state>: "fulfilled", <value>: [3] }`;

--- a/src/test/mochitest/test_reps_regexp.html
+++ b/src/test/mochitest/test_reps_regexp.html
@@ -18,7 +18,10 @@ Test RegExp rep
 <script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, RegExp } = REPS;
 
     let gripStub = {
@@ -33,8 +36,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, RegExp.rep, `Rep correctly selects ${RegExp.rep.displayName}`);
+    is(getRep(gripStub), RegExp.rep, "Rep correctly selects RegExp Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(RegExp.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_string.html
+++ b/src/test/mochitest/test_reps_string.html
@@ -17,7 +17,10 @@ Test String rep
 <script src="head.js" type="application/javascript"></script>
 <script type="application/javascript">
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, StringRep } = REPS;
 
   const test_cases = [{
@@ -79,8 +82,8 @@ window.onload = Task.async(function* () {
 
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, test_cases[0].props);
-    is(renderedRep.type, StringRep.rep, `Rep correctly selects ${StringRep.rep.displayName}`);
+    is(getRep(test_cases[0].props.object), StringRep.rep,
+      "Rep correctly selects String Rep");
 
     // Test rendering
     for (let test of test_cases) {

--- a/src/test/mochitest/test_reps_stylesheet.html
+++ b/src/test/mochitest/test_reps_stylesheet.html
@@ -18,7 +18,10 @@ Test Stylesheet rep
 <script type="application/javascript">
 window.onload = Task.async(function* () {
   try {
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, StyleSheet } = REPS;
 
     let gripStub = {
@@ -36,8 +39,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, StyleSheet.rep, `Rep correctly selects ${StyleSheet.rep.displayName}`);
+    is(getRep(gripStub), StyleSheet.rep, "Rep correctly selects StyleSheet Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(StyleSheet.rep, { object: gripStub });

--- a/src/test/mochitest/test_reps_symbol.html
+++ b/src/test/mochitest/test_reps_symbol.html
@@ -20,7 +20,10 @@ Test Symbol rep
 /* import-globals-from head.js */
 
 window.onload = Task.async(function* () {
-  const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+  const {
+    REPS,
+    getRep,
+  } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, SymbolRep } = REPS;
 
   let gripStubs = new Map();
@@ -34,13 +37,8 @@ window.onload = Task.async(function* () {
 
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(
-      Rep,
-      { object: gripStubs.get("testSymbolFoo")}
-    );
-
-    is(renderedRep.type, SymbolRep.rep,
-      `Rep correctly selects ${SymbolRep.rep.displayName}`);
+    is(getRep(gripStubs.get("testSymbolFoo")), SymbolRep.rep,
+      "Rep correctly selects SymbolRep Rep");
 
     // Test rendering
     yield testSymbol();

--- a/src/test/mochitest/test_reps_text-node.html
+++ b/src/test/mochitest/test_reps_text-node.html
@@ -22,6 +22,7 @@ window.onload = Task.async(function* () {
   const {
     REPS,
     MODE,
+    getRep,
     getSelectableInInspectorGrips,
   } = browserRequire("devtools/client/shared/components/reps/reps");
   let { Rep, TextNode } = REPS;
@@ -50,12 +51,8 @@ window.onload = Task.async(function* () {
 
   try {
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, {
-      object: gripStubs.get("testRendering")
-    });
-
-    is(renderedRep.type, TextNode.rep,
-      `Rep correctly selects ${TextNode.rep.displayName}`);
+    is(getRep(gripStubs.get("testRendering")), TextNode.rep,
+      "Rep correctly selects TextNode Rep");
 
     yield testRendering();
     yield testRenderingWithEOL();

--- a/src/test/mochitest/test_reps_undefined.html
+++ b/src/test/mochitest/test_reps_undefined.html
@@ -20,7 +20,10 @@ window.onload = Task.async(function* () {
   try {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");
     let React = browserRequire("devtools/client/shared/vendor/react");
-    const { REPS } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, Undefined } = REPS;
 
     let gripStub = {
@@ -28,8 +31,7 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Undefined.rep, `Rep correctly selects ${Undefined.rep.displayName}`);
+    is(getRep(gripStub), Undefined.rep, "Rep correctly selects Undefined Rep");
 
     // Test rendering
     const renderedComponent = renderComponent(Undefined.rep, {});

--- a/src/test/mochitest/test_reps_window.html
+++ b/src/test/mochitest/test_reps_window.html
@@ -21,7 +21,11 @@ window.onload = Task.async(function* () {
     let ReactDOM = browserRequire("devtools/client/shared/vendor/react-dom");
     let React = browserRequire("devtools/client/shared/vendor/react");
 
-    const { REPS, MODE } = browserRequire("devtools/client/shared/components/reps/reps");
+    const {
+      REPS,
+      MODE,
+      getRep,
+    } = browserRequire("devtools/client/shared/components/reps/reps");
     let { Rep, Window } = REPS;
 
     let gripStub = {
@@ -39,11 +43,10 @@ window.onload = Task.async(function* () {
     };
 
     // Test that correct rep is chosen
-    const renderedRep = shallowRenderComponent(Rep, { object: gripStub });
-    is(renderedRep.type, Window.rep, `Rep correctly selects ${Window.rep.displayName}`);
+    is(getRep(gripStub), Window.rep, "Rep correctly selects Window Rep");
 
     // Test rendering
-    const renderedComponent = renderComponent(Window.rep, { object: gripStub });
+    const renderedComponent = renderComponent(Rep, { object: gripStub });
     ok(renderedComponent.className.includes("objectBox-Window"), "Window rep has expected class name");
     is(renderedComponent.textContent, "Window about:newtab", "Window rep has expected text content");
     const innerNode = renderedComponent.querySelector(".objectPropValue");


### PR DESCRIPTION
Moving from classes to functions showed a solid 50-60% improvement in my test case (1000 Object reps).

There isn't much drawbacks of doing this since all the component were already stateless.

The only things I had to change were the tests that make sure the root `Rep` component chose the correct component given a specific grip. The solution I came with is to directly test the `getRep` function that `Rep` calls.
I wonder if this is enough though, because of course at some point `Rep` could do something wrong without being catch by the tests on `getRep`. 
To counter that, what would you think of testing all our components by rendering  `Rep(props)` instead of calling specific functions (e.g. `String(props)`) ?

