### PR TITLE
Allow string reps to leave whitespace unquoted

### DIFF
--- a/src/reps/long-string.js
+++ b/src/reps/long-string.js
@@ -14,6 +14,7 @@ const { span } = React.DOM;
  */
 LongStringRep.propTypes = {
   useQuotes: React.PropTypes.bool,
+  escapeWhitespace: React.PropTypes.bool,
   style: React.PropTypes.object,
   cropLimit: React.PropTypes.number.isRequired,
   member: React.PropTypes.string,
@@ -26,7 +27,8 @@ function LongStringRep(props) {
     member,
     object,
     style,
-    useQuotes = true
+    useQuotes = true,
+    escapeWhitespace = true,
   } = props;
   let {fullText, initial, length} = object;
 
@@ -42,7 +44,8 @@ function LongStringRep(props) {
   if (string.length < length) {
     string += "\u2026";
   }
-  let formattedString = useQuotes ? escapeString(string) : sanitizeString(string);
+  let formattedString = useQuotes ? escapeString(string, escapeWhitespace) :
+      sanitizeString(string);
   return span(config, formattedString);
 }
 

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -80,12 +80,17 @@ const escapeRegexp = new RegExp(
  *
  * @param {String} str
  *        the input
+ * @param {Boolean} escapeWhitespace
+ *        if true, TAB, CR, and NL characters will be escaped
  * @return {String} the escaped string
  */
-function escapeString(str) {
+function escapeString(str, escapeWhitespace) {
   return "\"" + str.replace(escapeRegexp, (match, offset) => {
     let c = match.charCodeAt(0);
     if (c in escapeMap) {
+      if (!escapeWhitespace && (c === 9 || c === 0xa || c === 0xd)) {
+        return match[0];
+      }
       return escapeMap[c];
     }
     if (c >= 0xd800 && c <= 0xdfff) {

--- a/src/reps/string.js
+++ b/src/reps/string.js
@@ -16,6 +16,7 @@ const { span } = React.DOM;
  */
 StringRep.propTypes = {
   useQuotes: React.PropTypes.bool,
+  escapeWhitespace: React.PropTypes.bool,
   style: React.PropTypes.object,
   object: React.PropTypes.string.isRequired,
   member: React.PropTypes.any,
@@ -29,6 +30,7 @@ function StringRep(props) {
     member,
     style,
     useQuotes = true,
+    escapeWhitespace = true,
   } = props;
 
   let config = {className: "objectBox objectBox-string"};
@@ -37,7 +39,7 @@ function StringRep(props) {
   }
 
   if (useQuotes) {
-    text = escapeString(text);
+    text = escapeString(text, escapeWhitespace);
   } else {
     text = sanitizeString(text);
   }

--- a/src/test/mochitest/test_reps_string.html
+++ b/src/test/mochitest/test_reps_string.html
@@ -78,6 +78,14 @@ window.onload = Task.async(function* () {
       useQuotes: true
     },
     result: "\"\ud83d\udeec\""
+  }, {
+    name: "testNoEscapeWhitespace",
+    props: {
+      object: "line 1\r\nline 2\n\tline 3",
+      useQuotes: true,
+      escapeWhitespace: false,
+    },
+    result: "\"line 1\r\nline 2\n\tline 3\""
   }];
 
   try {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1353038 notes that the
change to the console to quote string-valued results made `pprint`
effectively no longer pretty, as now embedded newlines are escaped.

This patch changes the two string reps to allow the caller to specify
whether whitespace should be passed through.  This will allow a fix in
the console.