### PR TITLE
Remove unnecessary attachedNodeFrontsByActor prop

### DIFF
--- a/src/launchpad/components/Result.js
+++ b/src/launchpad/components/Result.js
@@ -4,7 +4,6 @@ const { DOM: dom, PropTypes, createFactory } = React;
 const { MODE } = require("../../reps/constants");
 const Rep = createFactory(require("../../reps/rep").Rep);
 const Grip = require("../../reps/grip");
-const { getSelectableInInspectorGrips } = require("../../reps/rep-utils");
 
 const Result = React.createClass({
   displayName: "Result",
@@ -53,12 +52,6 @@ const Result = React.createClass({
         defaultRep: Grip,
         mode: MODE[modeKey],
         onInspectIconClick: nodeFront => console.log("inspectIcon click", nodeFront),
-        attachedNodeFrontsByActor: getSelectableInInspectorGrips(object)
-          .reduce((res, gripStub) => {
-            return Object.assign(res, {
-              [gripStub.actor]: gripStub
-            });
-          }, {})
       })
     );
   },


### PR DESCRIPTION
The property isn't needed anymore since we use `isConnected` on the grip to check if a node is in the DOM tree