### PR TITLE
Fix and export getGripPreviewItems() function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const {
   parseURLParams,
   getSelectableInInspectorGrips,
   maybeEscapePropertyName,
+  getGripPreviewItems,
 } = require("./reps/rep-utils");
 
 module.exports = {
@@ -17,4 +18,5 @@ module.exports = {
   parseURLEncodedText,
   parseURLParams,
   getSelectableInInspectorGrips,
+  getGripPreviewItems,
 };

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -362,10 +362,18 @@ function getGripPreviewItems(grip) {
     return [grip.preview.target];
   }
 
+  // RegEx Grip
+  if (grip.displayString) {
+    return [grip.displayString];
+  }
+
   // Generic Grip
   if (grip.preview && grip.preview.ownProperties) {
     let propertiesValues = Object.values(grip.preview.ownProperties)
       .map(property => property.value || property);
+
+    let propertyKeys = Object.keys(grip.preview.ownProperties);
+    propertiesValues = propertiesValues.concat(propertyKeys);
 
     // ArrayBuffer Grip
     if (grip.preview.safeGetterValues) {
@@ -383,7 +391,7 @@ function getGripPreviewItems(grip) {
 
 /**
  * Returns a new element wrapped with a component, props.objectLink if it exists,
- * or a span if there are multiple childs, or directly the child if only one is passed.
+ * or a span if there are multiple children, or directly the child if only one is passed.
  *
  * @param {Object} props A Rep "props" object that may contain `objectLink`
  *                 and `object` properties.
@@ -427,4 +435,5 @@ module.exports = {
   getSelectableInInspectorGrips,
   maybeEscapePropertyName,
   safeObjectLink,
+  getGripPreviewItems,
 };


### PR DESCRIPTION
This change is needed for bug https://bugzilla.mozilla.org/show_bug.cgi?id=1307879

- Including also object keys in the preview items
- Exporting `getGripPreviewItems`
- Support preview for RegEx

Honza