### PR TITLE
Include all properties from Event grip (getGripPreviewItems)

### DIFF
--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -359,7 +359,9 @@ function getGripPreviewItems(grip) {
 
   // Event Grip
   if (grip.preview && grip.preview.target) {
-    return [grip.preview.target];
+    let keys = Object.keys(grip.preview.properties);
+    let values = Object.values(grip.preview.properties);
+    return [grip.preview.target, ...keys, ...values];
   }
 
   // RegEx Grip


### PR DESCRIPTION
`getGripPreviewItems` should include also preview properties from Event grip.

mach test devtools/client/shared/components/reps/test/ => Passed:  505, Failed:  0

(this PR is for https://bugzilla.mozilla.org/show_bug.cgi?id=1307879)

Honza