### PR TITLE
Don't wrap PropRep elements in a span

### DIFF
--- a/src/reps/grip-map.js
+++ b/src/reps/grip-map.js
@@ -28,11 +28,12 @@ GripMap.propTypes = {
 };
 
 function GripMap(props) {
-  let object = props.object;
-  let propsArray = safeEntriesIterator(props, object,
-    (props.mode === MODE.LONG) ? 10 : 3);
+  let {
+    mode,
+    object,
+  } = props;
 
-  if (props.mode === MODE.TINY) {
+  if (mode === MODE.TINY) {
     return (
       span({className: "objectBox objectBox-object"},
         getTitle(props, object)
@@ -40,13 +41,16 @@ function GripMap(props) {
     );
   }
 
+  let propsArray = safeEntriesIterator(props, object,
+    (props.mode === MODE.LONG) ? 10 : 3);
+
   return (
     span({className: "objectBox objectBox-object"},
       getTitle(props, object),
       safeObjectLink(props, {
         className: "objectLeftBrace",
       }, " { "),
-      propsArray,
+      ...propsArray,
       safeObjectLink(props, {
         className: "objectRightBrace",
       }, " }")
@@ -101,7 +105,23 @@ function entriesIterator(props, object, max) {
     }));
   }
 
-  return entries;
+  return unfoldEntries(entries);
+}
+
+function unfoldEntries(items) {
+  return items.reduce((res, item, index) => {
+    if (Array.isArray(item)) {
+      res = res.concat(item);
+    } else {
+      res.push(item);
+    }
+
+    // Interleave commas between elements
+    if (index !== items.length - 1) {
+      res.push(", ");
+    }
+    return res;
+  }, []);
 }
 
 /**
@@ -134,9 +154,6 @@ function getEntries(props, entries, indexes) {
       name: key,
       equal: ": ",
       object: value,
-      // Do not add a trailing comma on the last entry
-      // if there won't be a "more..." item.
-      delim: (i < indexes.length - 1 || indexes.length < entries.length) ? ", " : null,
       mode: MODE.TINY,
       objectLink,
       onDOMNodeMouseOver,

--- a/src/reps/object.js
+++ b/src/reps/object.js
@@ -90,26 +90,40 @@ function propIterator(props, object, max) {
     );
   }
 
-  const truncated = Object.keys(object).length > max;
-  let propsArray = getPropsArray(interestingObject, truncated);
-  if (truncated) {
+  let propsArray = getPropsArray(interestingObject);
+  if (Object.keys(object).length > max) {
     propsArray.push(Caption({
       object: safeObjectLink(props, {},
         (Object.keys(object).length - max) + " more…")
     }));
   }
 
-  return propsArray;
+  return unfoldProps(propsArray);
+}
+
+function unfoldProps(items) {
+  return items.reduce((res, item, index) => {
+    if (Array.isArray(item)) {
+      res = res.concat(item);
+    } else {
+      res.push(item);
+    }
+
+    // Interleave commas between elements
+    if (index !== items.length - 1) {
+      res.push(", ");
+    }
+    return res;
+  }, []);
 }
 
 /**
  * Get an array of components representing the properties of the object
  *
  * @param {Object} object
- * @param {Boolean} truncated true if the object is truncated.
  * @return {Array} Array of PropRep.
  */
-function getPropsArray(object, truncated) {
+function getPropsArray(object) {
   let propsArray = [];
 
   if (!object) {
@@ -124,7 +138,6 @@ function getPropsArray(object, truncated) {
     name,
     object: object[name],
     equal: ": ",
-    delim: i !== objectKeys.length - 1 || truncated ? ", " : null,
   }));
 }
 

--- a/src/reps/promise.js
+++ b/src/reps/promise.js
@@ -72,17 +72,23 @@ function getProps(props, promiseState) {
     keys.push("value");
   }
 
-  return keys.map((key, i) => {
+  return keys.reduce((res, key, i) => {
     let object = promiseState[key];
-    return PropRep(Object.assign({}, props, {
+    res = res.concat(PropRep(Object.assign({}, props, {
       mode: MODE.TINY,
       name: `<${key}>`,
       object,
       equal: ": ",
-      delim: i < keys.length - 1 ? ", " : null,
       suppressQuotes: true,
-    }));
-  });
+    })));
+
+    // Interleave commas between elements
+    if (i !== keys.length - 1) {
+      res.push(", ");
+    }
+
+    return res;
+  }, []);
 }
 
 // Registration

--- a/src/reps/prop-rep.js
+++ b/src/reps/prop-rep.js
@@ -21,8 +21,6 @@ PropRep.propTypes = {
   ]).isRequired,
   // Equal character rendered between property name and value.
   equal: React.PropTypes.string,
-  // Delimiter character used to separate individual properties.
-  delim: React.PropTypes.string,
   // @TODO Change this to Object.values once it's supported in Node's version of V8
   mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
   objectLink: React.PropTypes.func,
@@ -35,6 +33,13 @@ PropRep.propTypes = {
   suppressQuotes: React.PropTypes.bool,
 };
 
+/**
+ * Function that given a name, a delimiter and an object returns an array
+ * of React elements representing an object property (e.g. `name: value`)
+ *
+ * @param {Object} props
+ * @return {Array(3)} Array of React elements.
+ */
 function PropRep(props) {
   const Grip = require("./grip");
   const { Rep } = require("./rep");
@@ -43,7 +48,6 @@ function PropRep(props) {
     name,
     mode,
     equal,
-    delim,
     suppressQuotes,
   } = props;
 
@@ -63,23 +67,13 @@ function PropRep(props) {
     }));
   }
 
-  let delimElement;
-  if (delim) {
-    delimElement = span({
-      "className": "objectComma"
-    }, delim);
-  }
-
-  return (
-    span({},
-      key,
-      span({
-        "className": "objectEqual"
-      }, equal),
-      Rep(Object.assign({}, props)),
-      delimElement,
-    )
-  );
+  return [
+    key,
+    span({
+      "className": "objectEqual"
+    }, equal),
+    Rep(Object.assign({}, props)),
+  ];
 }
 
 // Exports from this module

--- a/src/reps/prop-rep.js
+++ b/src/reps/prop-rep.js
@@ -38,7 +38,7 @@ PropRep.propTypes = {
  * of React elements representing an object property (e.g. `name: value`)
  *
  * @param {Object} props
- * @return {Array(3)} Array of React elements.
+ * @return {Array} Array of React elements.
  */
 function PropRep(props) {
   const Grip = require("./grip");


### PR DESCRIPTION
Instead of wrapping PropRep in a span which doesn't serve any purpose
except complying to React limits, directly return an array of the
elements we want.
This implies changes in the Rep that uses PropRep since they have to "unfold"
the PropRep elements.
We take advantage of this rewrite to simplify how we deal with commas in Rep
that have multiple children which need to be delimited by commas.
Also fixed some case where we were doing unnecessary work in TINY mode.