### PR TITLE
Remove createFactories from Reps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@
 const { MODE } = require("./reps/constants");
 const { REPS, getRep } = require("./reps/rep");
 const {
-  createFactories,
   parseURLEncodedText,
   parseURLParams,
   getSelectableInInspectorGrips,
@@ -17,7 +16,6 @@ module.exports = {
   REPS,
   getRep,
   MODE,
-  createFactories,
   maybeEscapePropertyName,
   parseURLEncodedText,
   parseURLParams,

--- a/src/reps/rep-utils.js
+++ b/src/reps/rep-utils.js
@@ -9,19 +9,6 @@ const React = require("react");
 const nodeConstants = require("../shared/dom-node-constants");
 
 /**
- * Create React factories for given arguments.
- * Example:
- *   const { Rep } = createFactories(require("./rep"));
- */
-function createFactories(args) {
-  let result = {};
-  for (let p in args) {
-    result[p] = React.createFactory(args[p]);
-  }
-  return result;
-}
-
-/**
  * Returns true if the given object is a grip (see RDP protocol)
  */
 function isGrip(object) {
@@ -426,7 +413,6 @@ function safeObjectLink(props, config, ...children) {
 }
 
 module.exports = {
-  createFactories,
   isGrip,
   cropString,
   rawCropString,


### PR DESCRIPTION
Fixes  #125

The function is not used in Reps anymore and was moved to mozilla-central
in https://bugzilla.mozilla.org/show_bug.cgi?id=1355454.
We can safely delete it from this repo.